### PR TITLE
Improve scan pipeline: active learning + handwritten recipe support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ frontend/node_modules/
 frontend/dist/
 .env
 docker-compose.prod.yml
+*.bak
+.DS_Store
+.tool-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ./gradlew --no-daemon bootJar -x test
 
 FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tesseract-ocr curl && rm -rf /var/lib/apt/lists/* \
+    tesseract-ocr libheif-examples curl && rm -rf /var/lib/apt/lists/* \
     && curl -L -o /usr/share/tesseract-ocr/5/tessdata/eng.traineddata \
        https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata/

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,6 +15,9 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 10M;
+        proxy_read_timeout 600s;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
     }
 
     location /swagger-ui {

--- a/frontend/src/recipes/RecipeImportPage.tsx
+++ b/frontend/src/recipes/RecipeImportPage.tsx
@@ -8,6 +8,8 @@ interface ImportedIngredient {
   quantity: number;
   unit: string;
   rawText: string;
+  prepNote?: string;
+  section?: string;
 }
 
 interface ImportedPreview {
@@ -26,7 +28,7 @@ interface IngredientPreparation {
   shoppingListExclude: boolean;
 }
 
-const UNITS = ['TSP', 'TBSP', 'CUP', 'PINT', 'QUART', 'GALLON', 'HALF_GALLON', 'WHOLE', 'LBS', 'OZ', 'PINCH', 'PIECE'];
+const UNITS = ['TSP', 'TBSP', 'CUP', 'PINT', 'QUART', 'GALLON', 'HALF_GALLON', 'FL_OZ', 'WHOLE', 'LBS', 'OZ', 'PINCH', 'PIECE', 'G', 'ML', 'KG', 'L'];
 const STORAGE_CATEGORIES = ['PANTRY', 'FROZEN', 'FRESH', 'REFRIGERATED', 'SPICE_RACK', 'COUNTER'];
 const GROCERY_CATEGORIES = ['PRODUCE', 'MEAT', 'DAIRY', 'BAKING', 'SPICES', 'ETHNIC', 'BULK', 'CANNED', 'BAKERY', 'DELI', 'HOUSEHOLD', 'OILS_CONDIMENTS', 'FROZEN'];
 
@@ -189,30 +191,43 @@ export function RecipeImportPage() {
             </div>
             <p className="muted">New ingredients will be reviewed in the next step.</p>
             {ingredients.map((ing, i) => (
-              <div key={i} className="ingredient-row">
-                <input
-                  type="text"
-                  value={ing.name}
-                  onChange={e => updateIngredient(i, 'name', e.target.value)}
-                  style={{ flex: 2 }}
-                  placeholder="Ingredient name"
-                />
-                <input
-                  type="number"
-                  value={ing.quantity}
-                  onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
-                  step="0.01"
-                  min="0"
-                  style={{ flex: 1 }}
-                />
-                <select
-                  value={ing.unit}
-                  onChange={e => updateIngredient(i, 'unit', e.target.value)}
-                  style={{ flex: 1 }}
-                >
-                  {UNITS.map(u => <option key={u} value={u}>{u}</option>)}
-                </select>
-                <button type="button" className="btn btn-danger btn-small" onClick={() => removeIngredient(i)}>X</button>
+              <div key={i}>
+                {ing.section && (i === 0 || ingredients[i - 1]?.section !== ing.section) && (
+                  <h3 style={{ margin: '1rem 0 0.5rem', fontSize: '0.95rem', color: '#666', borderBottom: '1px solid #ddd', paddingBottom: '0.25rem' }}>
+                    {ing.section}
+                  </h3>
+                )}
+                <div className="ingredient-row">
+                  <div style={{ flex: 2, display: 'flex', flexDirection: 'column', gap: '0.15rem' }}>
+                    <input
+                      type="text"
+                      value={ing.name}
+                      onChange={e => updateIngredient(i, 'name', e.target.value)}
+                      placeholder="Ingredient name"
+                    />
+                    {ing.prepNote && (
+                      <span style={{ fontSize: '0.8rem', color: '#888', fontStyle: 'italic', paddingLeft: '0.25rem' }}>
+                        Prep: {ing.prepNote}
+                      </span>
+                    )}
+                  </div>
+                  <input
+                    type="number"
+                    value={ing.quantity}
+                    onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
+                    step="0.01"
+                    min="0"
+                    style={{ flex: 1 }}
+                  />
+                  <select
+                    value={ing.unit}
+                    onChange={e => updateIngredient(i, 'unit', e.target.value)}
+                    style={{ flex: 1 }}
+                  >
+                    {UNITS.map(u => <option key={u} value={u}>{u}</option>)}
+                  </select>
+                  <button type="button" className="btn btn-danger btn-small" onClick={() => removeIngredient(i)}>X</button>
+                </div>
               </div>
             ))}
             {ingredients.length === 0 && <p className="muted">No ingredients parsed</p>}

--- a/frontend/src/recipes/RecipeScanPage.tsx
+++ b/frontend/src/recipes/RecipeScanPage.tsx
@@ -9,6 +9,7 @@ interface ImportedIngredient {
   quantity: number;
   unit: string;
   rawText: string;
+  prepNote?: string;
 }
 
 interface ImportedPreview {
@@ -19,6 +20,11 @@ interface ImportedPreview {
   sourceUrl: string;
 }
 
+interface ScanResponse {
+  scanSessionId: string;
+  recipes: ImportedPreview[];
+}
+
 interface IngredientPreparation {
   name: string;
   status: 'EXISTING' | 'NEW';
@@ -27,7 +33,7 @@ interface IngredientPreparation {
   shoppingListExclude: boolean;
 }
 
-const UNITS = ['TSP', 'TBSP', 'CUP', 'PINT', 'QUART', 'GALLON', 'HALF_GALLON', 'WHOLE', 'LBS', 'OZ', 'PINCH', 'PIECE'];
+const UNITS = ['TSP', 'TBSP', 'CUP', 'PINT', 'QUART', 'GALLON', 'HALF_GALLON', 'FL_OZ', 'WHOLE', 'LBS', 'OZ', 'PINCH', 'PIECE', 'G', 'ML', 'KG', 'L'];
 const STORAGE_CATEGORIES = ['PANTRY', 'FROZEN', 'FRESH', 'REFRIGERATED', 'SPICE_RACK', 'COUNTER'];
 const GROCERY_CATEGORIES = ['PRODUCE', 'MEAT', 'DAIRY', 'BAKING', 'SPICES', 'ETHNIC', 'BULK', 'CANNED', 'BAKERY', 'DELI', 'HOUSEHOLD', 'OILS_CONDIMENTS', 'FROZEN'];
 
@@ -36,24 +42,42 @@ export function RecipeScanPage() {
   const [file, setFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [preview, setPreview] = useState<ImportedPreview | null>(null);
 
+  // Multi-recipe state
+  const [scanSessionId, setScanSessionId] = useState<string | null>(null);
+  const [recipes, setRecipes] = useState<ImportedPreview[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [savedIndices, setSavedIndices] = useState<Set<number>>(new Set());
+
+  // Edit state for selected recipe
   const [name, setName] = useState('');
   const [instructions, setInstructions] = useState('');
   const [baseServings, setBaseServings] = useState(1);
   const [ingredients, setIngredients] = useState<ImportedIngredient[]>([]);
   const [saving, setSaving] = useState(false);
 
-  const [step, setStep] = useState<'edit' | 'review'>('edit');
+  const [step, setStep] = useState<'upload' | 'select' | 'edit' | 'review'>('upload');
   const [newIngredients, setNewIngredients] = useState<IngredientPreparation[]>([]);
+
+  const loadRecipe = (index: number) => {
+    const recipe = recipes[index];
+    setSelectedIndex(index);
+    setName(recipe.name);
+    setInstructions(recipe.instructions);
+    setBaseServings(recipe.baseServings);
+    setIngredients(recipe.ingredients);
+    setStep('edit');
+  };
 
   const handleScan = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!file) return;
     setError('');
     setLoading(true);
-    setPreview(null);
-    setStep('edit');
+    setRecipes([]);
+    setScanSessionId(null);
+    setSavedIndices(new Set());
+    setStep('upload');
 
     const formData = new FormData();
     formData.append('file', file);
@@ -71,12 +95,17 @@ export function RecipeScanPage() {
         throw new Error(body.error || `HTTP ${response.status}`);
       }
 
-      const data: ImportedPreview = await response.json();
-      setPreview(data);
-      setName(data.name);
-      setInstructions(data.instructions);
-      setBaseServings(data.baseServings);
-      setIngredients(data.ingredients);
+      const data: ScanResponse = await response.json();
+      setScanSessionId(data.scanSessionId);
+      setRecipes(data.recipes);
+
+      if (data.recipes.length === 0) {
+        setError('No recipes could be extracted from the image');
+      } else if (data.recipes.length === 1) {
+        loadRecipe(0);
+      } else {
+        setStep('select');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Scan failed');
     } finally {
@@ -117,7 +146,7 @@ export function RecipeScanPage() {
   };
 
   const saveRecipe = async () => {
-    const body = {
+    const body: Record<string, unknown> = {
       name,
       instructions: instructions || null,
       baseServings,
@@ -129,8 +158,27 @@ export function RecipeScanPage() {
         unit: ing.unit,
       })),
     };
+
+    // Include scan session metadata for training pair generation
+    if (scanSessionId) {
+      body.scanSessionId = scanSessionId;
+      body.scanRecipeIndex = selectedIndex;
+    }
+
     const created = await apiPost<{ id: string }>('/api/v1/recipes', body);
-    navigate(`/recipes/${created.id}`);
+
+    // Track saved recipe
+    const newSaved = new Set(savedIndices);
+    newSaved.add(selectedIndex);
+    setSavedIndices(newSaved);
+
+    // If multi-recipe and more unsaved, go back to selection
+    const unsaved = recipes.filter((_, i) => !newSaved.has(i));
+    if (recipes.length > 1 && unsaved.length > 0) {
+      setStep('select');
+    } else {
+      navigate(`/recipes/${created.id}`);
+    }
   };
 
   const handleConfirmAndSave = async () => {
@@ -168,7 +216,7 @@ export function RecipeScanPage() {
           Upload photo or PDF of recipe
           <input
             type="file"
-            accept="image/*,application/pdf"
+            accept="image/*,.heic,.heif,application/pdf"
             onChange={e => setFile(e.target.files?.[0] || null)}
             required
           />
@@ -180,9 +228,54 @@ export function RecipeScanPage() {
 
       {error && <div className="error">{error}</div>}
 
-      {step === 'edit' && preview && (
+      {/* Recipe selection step (multi-recipe) */}
+      {step === 'select' && recipes.length > 1 && (
         <div className="recipe-form">
-          <p className="muted">Scanned text extracted via OCR — review and edit below</p>
+          <h2>{recipes.length} Recipes Found</h2>
+          <p className="muted">Select a recipe to review and save.</p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+            {recipes.map((recipe, i) => (
+              <button
+                key={i}
+                className={`btn ${savedIndices.has(i) ? '' : 'btn-primary'}`}
+                style={{
+                  textAlign: 'left',
+                  padding: '1rem',
+                  opacity: savedIndices.has(i) ? 0.5 : 1,
+                }}
+                onClick={() => loadRecipe(i)}
+                disabled={savedIndices.has(i)}
+              >
+                <strong>{recipe.name}</strong>
+                <span style={{ fontSize: '0.85rem', color: '#888', marginLeft: '0.75rem' }}>
+                  {recipe.ingredients.length} ingredients
+                  {savedIndices.has(i) && ' \u2014 saved'}
+                </span>
+              </button>
+            ))}
+          </div>
+          {savedIndices.size > 0 && savedIndices.size < recipes.length && (
+            <p className="muted" style={{ marginTop: '1rem' }}>
+              {savedIndices.size} of {recipes.length} saved
+            </p>
+          )}
+          {savedIndices.size === recipes.length && (
+            <div style={{ marginTop: '1rem' }}>
+              <p className="muted">All recipes saved!</p>
+              <button className="btn" onClick={() => navigate('/recipes')}>Go to Recipes</button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Edit step */}
+      {step === 'edit' && (
+        <div className="recipe-form">
+          <p className="muted">
+            {recipes.length > 1
+              ? `Editing recipe ${selectedIndex + 1} of ${recipes.length} \u2014 review and save below`
+              : 'Scanned text extracted \u2014 review and edit below'}
+          </p>
 
           <label>
             Recipe Name
@@ -241,30 +334,37 @@ export function RecipeScanPage() {
                     {groupIngs.map((ing, j) => {
                       const i = group.startIndex + j;
                       return (
-                        <div key={i} className="ingredient-row">
-                          <input
-                            type="text"
-                            value={ing.name}
-                            onChange={e => updateIngredient(i, 'name', e.target.value)}
-                            style={{ flex: 2 }}
-                            placeholder="Ingredient name"
-                          />
-                          <input
-                            type="number"
-                            value={ing.quantity}
-                            onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
-                            step="0.01"
-                            min="0"
-                            style={{ flex: 1 }}
-                          />
-                          <select
-                            value={ing.unit}
-                            onChange={e => updateIngredient(i, 'unit', e.target.value)}
-                            style={{ flex: 1 }}
-                          >
-                            {UNITS.map(u => <option key={u} value={u}>{u}</option>)}
-                          </select>
-                          <button type="button" className="btn btn-danger btn-small" onClick={() => removeIngredient(i)}>X</button>
+                        <div key={i}>
+                          <div className="ingredient-row">
+                            <input
+                              type="text"
+                              value={ing.name}
+                              onChange={e => updateIngredient(i, 'name', e.target.value)}
+                              style={{ flex: 2 }}
+                              placeholder="Ingredient name"
+                            />
+                            <input
+                              type="number"
+                              value={ing.quantity}
+                              onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
+                              step="0.01"
+                              min="0"
+                              style={{ flex: 1 }}
+                            />
+                            <select
+                              value={ing.unit}
+                              onChange={e => updateIngredient(i, 'unit', e.target.value)}
+                              style={{ flex: 1 }}
+                            >
+                              {UNITS.map(u => <option key={u} value={u}>{u}</option>)}
+                            </select>
+                            <button type="button" className="btn btn-danger btn-small" onClick={() => removeIngredient(i)}>X</button>
+                          </div>
+                          {ing.prepNote && (
+                            <span style={{ fontSize: '0.8rem', color: '#888', fontStyle: 'italic', paddingLeft: '0.25rem' }}>
+                              Prep: {ing.prepNote}
+                            </span>
+                          )}
                         </div>
                       );
                     })}
@@ -279,11 +379,15 @@ export function RecipeScanPage() {
             <button className="btn btn-primary" onClick={handleSave} disabled={saving}>
               {saving ? 'Checking ingredients...' : 'Save Recipe'}
             </button>
-            <button className="btn" onClick={() => { setPreview(null); setFile(null); }}>Discard</button>
+            {recipes.length > 1 && (
+              <button className="btn" onClick={() => setStep('select')}>Back to Selection</button>
+            )}
+            <button className="btn" onClick={() => { setRecipes([]); setScanSessionId(null); setFile(null); setStep('upload'); }}>Discard</button>
           </div>
         </div>
       )}
 
+      {/* Review new ingredients step */}
       {step === 'review' && (
         <div className="recipe-form">
           <h2>Review New Ingredients</h2>

--- a/src/main/java/com/endoran/foodplan/controller/RecipeController.java
+++ b/src/main/java/com/endoran/foodplan/controller/RecipeController.java
@@ -4,6 +4,7 @@ import com.endoran.foodplan.dto.CreateRecipeRequest;
 import com.endoran.foodplan.dto.ImportRecipeRequest;
 import com.endoran.foodplan.dto.ImportedRecipePreview;
 import com.endoran.foodplan.dto.RecipeResponse;
+import com.endoran.foodplan.dto.ScanResult;
 import com.endoran.foodplan.dto.UpdateRecipeRequest;
 import com.endoran.foodplan.service.RecipeImportException;
 import com.endoran.foodplan.service.RecipeImportService;
@@ -109,11 +110,13 @@ public class RecipeController {
     }
 
     @PostMapping(value = "/scan", consumes = "multipart/form-data")
-    public ResponseEntity<ImportedRecipePreview> scanFile(
+    public ResponseEntity<ScanResult> scanFile(
+            @AuthenticationPrincipal Jwt jwt,
             @RequestParam("file") MultipartFile file) {
         try {
-            ImportedRecipePreview preview = recipeScanService.scanFile(file);
-            return ResponseEntity.ok(preview);
+            String orgId = jwt.getClaimAsString("orgId");
+            ScanResult result = recipeScanService.scanFile(file, orgId);
+            return ResponseEntity.ok(result);
         } catch (RecipeImportException ex) {
             throw ex;
         } catch (Exception ex) {

--- a/src/main/java/com/endoran/foodplan/dto/CreateRecipeRequest.java
+++ b/src/main/java/com/endoran/foodplan/dto/CreateRecipeRequest.java
@@ -11,5 +11,7 @@ public record CreateRecipeRequest(
         @NotBlank @Size(min = 1, max = 200) String name,
         String instructions,
         @Min(1) int baseServings,
-        @Valid List<RecipeIngredientRequest> ingredients
+        @Valid List<RecipeIngredientRequest> ingredients,
+        String scanSessionId,
+        Integer scanRecipeIndex
 ) {}

--- a/src/main/java/com/endoran/foodplan/dto/ImportedIngredientPreview.java
+++ b/src/main/java/com/endoran/foodplan/dto/ImportedIngredientPreview.java
@@ -7,5 +7,6 @@ public record ImportedIngredientPreview(
         String name,
         BigDecimal quantity,
         String unit,
-        String rawText
+        String rawText,
+        String prepNote
 ) {}

--- a/src/main/java/com/endoran/foodplan/dto/ScanResult.java
+++ b/src/main/java/com/endoran/foodplan/dto/ScanResult.java
@@ -1,0 +1,5 @@
+package com.endoran.foodplan.dto;
+
+import java.util.List;
+
+public record ScanResult(String scanSessionId, List<ImportedRecipePreview> recipes) {}

--- a/src/main/java/com/endoran/foodplan/model/MeasurementUnit.java
+++ b/src/main/java/com/endoran/foodplan/model/MeasurementUnit.java
@@ -2,5 +2,6 @@ package com.endoran.foodplan.model;
 
 public enum MeasurementUnit {
     TSP, TBSP, FL_OZ, CUP, PINT, QUART, GALLON, HALF_GALLON,
-    WHOLE, LBS, OZ, PINCH, PIECE
+    WHOLE, LBS, OZ, PINCH, PIECE,
+    G, ML, KG, L
 }

--- a/src/main/java/com/endoran/foodplan/model/ScanSession.java
+++ b/src/main/java/com/endoran/foodplan/model/ScanSession.java
@@ -1,0 +1,43 @@
+package com.endoran.foodplan.model;
+
+import com.endoran.foodplan.dto.ImportedRecipePreview;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+
+@Document(collection = "scan_sessions")
+public class ScanSession {
+
+    @Id
+    private String id;
+    private String orgId;
+    private byte[] imageData;
+    private String imageContentType;
+    private List<ImportedRecipePreview> modelOutput;
+    private String extractionTier;
+
+    @Indexed(expireAfterSeconds = 86400)
+    private Instant createdAt;
+
+    public ScanSession() {
+        this.createdAt = Instant.now();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getOrgId() { return orgId; }
+    public void setOrgId(String orgId) { this.orgId = orgId; }
+    public byte[] getImageData() { return imageData; }
+    public void setImageData(byte[] imageData) { this.imageData = imageData; }
+    public String getImageContentType() { return imageContentType; }
+    public void setImageContentType(String imageContentType) { this.imageContentType = imageContentType; }
+    public List<ImportedRecipePreview> getModelOutput() { return modelOutput; }
+    public void setModelOutput(List<ImportedRecipePreview> modelOutput) { this.modelOutput = modelOutput; }
+    public String getExtractionTier() { return extractionTier; }
+    public void setExtractionTier(String extractionTier) { this.extractionTier = extractionTier; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/endoran/foodplan/model/TrainingPair.java
+++ b/src/main/java/com/endoran/foodplan/model/TrainingPair.java
@@ -1,0 +1,48 @@
+package com.endoran.foodplan.model;
+
+import com.endoran.foodplan.dto.ImportedRecipePreview;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document(collection = "training_pairs")
+public class TrainingPair {
+
+    @Id
+    private String id;
+    private String orgId;
+    private String scanSessionId;
+    private byte[] imageData;
+    private String imageContentType;
+    private ImportedRecipePreview modelOutput;
+    private ImportedRecipePreview correctedOutput;
+    private String extractionTier;
+    private boolean hasCorrections;
+    private Instant createdAt;
+
+    public TrainingPair() {
+        this.createdAt = Instant.now();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getOrgId() { return orgId; }
+    public void setOrgId(String orgId) { this.orgId = orgId; }
+    public String getScanSessionId() { return scanSessionId; }
+    public void setScanSessionId(String scanSessionId) { this.scanSessionId = scanSessionId; }
+    public byte[] getImageData() { return imageData; }
+    public void setImageData(byte[] imageData) { this.imageData = imageData; }
+    public String getImageContentType() { return imageContentType; }
+    public void setImageContentType(String imageContentType) { this.imageContentType = imageContentType; }
+    public ImportedRecipePreview getModelOutput() { return modelOutput; }
+    public void setModelOutput(ImportedRecipePreview modelOutput) { this.modelOutput = modelOutput; }
+    public ImportedRecipePreview getCorrectedOutput() { return correctedOutput; }
+    public void setCorrectedOutput(ImportedRecipePreview correctedOutput) { this.correctedOutput = correctedOutput; }
+    public String getExtractionTier() { return extractionTier; }
+    public void setExtractionTier(String extractionTier) { this.extractionTier = extractionTier; }
+    public boolean isHasCorrections() { return hasCorrections; }
+    public void setHasCorrections(boolean hasCorrections) { this.hasCorrections = hasCorrections; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/endoran/foodplan/repository/ScanSessionRepository.java
+++ b/src/main/java/com/endoran/foodplan/repository/ScanSessionRepository.java
@@ -1,0 +1,7 @@
+package com.endoran.foodplan.repository;
+
+import com.endoran.foodplan.model.ScanSession;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ScanSessionRepository extends MongoRepository<ScanSession, String> {
+}

--- a/src/main/java/com/endoran/foodplan/repository/TrainingPairRepository.java
+++ b/src/main/java/com/endoran/foodplan/repository/TrainingPairRepository.java
@@ -1,0 +1,10 @@
+package com.endoran.foodplan.repository;
+
+import com.endoran.foodplan.model.TrainingPair;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface TrainingPairRepository extends MongoRepository<TrainingPair, String> {
+    List<TrainingPair> findByHasCorrectionsTrue();
+}

--- a/src/main/java/com/endoran/foodplan/service/OllamaIngredientParser.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaIngredientParser.java
@@ -1,0 +1,214 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.dto.ImportedIngredientPreview;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OllamaIngredientParser {
+
+    private static final Logger log = LoggerFactory.getLogger(OllamaIngredientParser.class);
+
+    private final String baseUrl;
+    private final String textModel;
+    private final int timeout;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    private static final String SYSTEM_PROMPT = """
+            You are a recipe ingredient parser. Your job is to convert raw ingredient strings into structured, \
+            shopping-friendly data. You also enrich recipe instructions with parenthetical prep annotations.
+
+            RULES:
+            - Valid units: TSP, TBSP, CUP, PINT, QUART, GALLON, HALF_GALLON, FL_OZ, WHOLE, LBS, OZ, PINCH, PIECE, G, ML, KG, L
+            - Use WHOLE for items counted by number (e.g., "3 eggs" -> quantity 3, unit WHOLE)
+            - Use PINCH for "to taste", dashes, or pinches
+            - COMPOUND ingredients ("salt and pepper", "oil and vinegar") -> split into separate entries sharing the same rawIndex
+            - NAME = the shopping-list item. Strip ALL prep verbs: peeled, chopped, minced, sliced, diced, grated, crushed, melted, softened, julienned, trimmed, halved, quartered, seeded, deveined, shelled, cubed, cut into pieces, torn, etc.
+            - PREP NOTE = preparation guidance stripped from the name. Include size/shape descriptors: "thinly sliced", "cut into 1-inch pieces", "peeled and left whole"
+            - ALTERNATIVES: "X or Y flour" -> pick the first option. "Diamond Crystal or Morton" -> ignore brands, keep the ingredient
+            - Unicode fractions -> decimals. Ranges -> midpoint.
+            - rawIndex = 0-based index into the original ingredient list (compounds share an index)
+            - INSTRUCTIONS: Where an ingredient is first used, add a parenthetical prep note if one was extracted. Example: "Add the garlic (minced) and cook..."
+            - Return ONLY valid JSON. No markdown fences. No explanation.""";
+
+    public OllamaIngredientParser(
+            @Value("${ollama.host:}") String host,
+            @Value("${ollama.port:11434}") int port,
+            @Value("${ollama.text-model:qwen2.5:32b-instruct-q4_K_M}") String textModel,
+            @Value("${ollama.timeout:120}") int timeout,
+            ObjectMapper objectMapper) {
+        this.baseUrl = host.isBlank() ? "" : "http://" + host + ":" + port;
+        this.textModel = textModel;
+        this.timeout = timeout;
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    public boolean isAvailable() {
+        if (baseUrl.isBlank()) return false;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/"))
+                    .GET()
+                    .timeout(Duration.ofSeconds(3))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.statusCode() == 200;
+        } catch (Exception e) {
+            log.debug("Ollama health check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public ParsedIngredientResult parseIngredients(List<String> rawIngredients, String instructions) {
+        if (baseUrl.isBlank()) return null;
+
+        try {
+            String userPrompt = buildUserPrompt(rawIngredients, instructions);
+            String responseJson = callOllama(userPrompt);
+            ParsedIngredientResult result = parseResponse(responseJson);
+
+            // Sanity check: discard if LLM returns >2x original ingredient count
+            if (result != null && result.ingredients().size() > rawIngredients.size() * 2) {
+                log.warn("LLM returned {} ingredients for {} raw inputs — discarding as likely hallucination",
+                        result.ingredients().size(), rawIngredients.size());
+                return null;
+            }
+
+            // Sanity check: discard if LLM returns zero ingredients
+            if (result != null && result.ingredients().isEmpty()) {
+                log.warn("LLM returned zero ingredients — discarding");
+                return null;
+            }
+
+            return result;
+        } catch (Exception e) {
+            log.warn("LLM ingredient parsing failed: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String buildUserPrompt(List<String> rawIngredients, String instructions) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Parse these raw ingredient strings into structured data.\n\n");
+        sb.append("Raw ingredients:\n");
+        for (int i = 0; i < rawIngredients.size(); i++) {
+            sb.append(i).append(": \"").append(rawIngredients.get(i)).append("\"\n");
+        }
+        if (instructions != null && !instructions.isBlank()) {
+            sb.append("\nInstructions:\n").append(instructions).append("\n");
+        }
+        sb.append("""
+
+                Return JSON in this exact format:
+                {
+                  "ingredients": [
+                    {"name": "ingredient name", "quantity": 1.0, "unit": "CUP", "section": null, "prepNote": null, "rawIndex": 0}
+                  ],
+                  "instructions": "1. Enriched instructions with (prep notes) added..."
+                }""");
+        return sb.toString();
+    }
+
+    private String callOllama(String userPrompt) throws Exception {
+        Map<String, Object> systemMessage = Map.of("role", "system", "content", SYSTEM_PROMPT);
+        Map<String, Object> userMessage = Map.of("role", "user", "content", userPrompt);
+
+        Map<String, Object> body = Map.of(
+                "model", textModel,
+                "messages", List.of(systemMessage, userMessage),
+                "temperature", 0.1,
+                "max_tokens", 8192);
+
+        String requestBody = objectMapper.writeValueAsString(body);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/v1/chat/completions"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .timeout(Duration.ofSeconds(timeout))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("Ollama returned " + response.statusCode() + ": " + response.body());
+        }
+
+        JsonNode root = objectMapper.readTree(response.body());
+        return root.at("/choices/0/message/content").asText();
+    }
+
+    private ParsedIngredientResult parseResponse(String content) {
+        String json = content.strip();
+        // Strip markdown fences if present
+        if (json.startsWith("```")) {
+            json = json.replaceFirst("^```(?:json)?\\s*", "").replaceFirst("\\s*```$", "");
+        }
+
+        try {
+            LlmParseResponse llm = objectMapper.readValue(json, LlmParseResponse.class);
+
+            List<ImportedIngredientPreview> ingredients = new ArrayList<>();
+            for (LlmParsedIngredient ing : llm.ingredients) {
+                String unit = ing.unit != null ? ing.unit.toUpperCase() : "WHOLE";
+                BigDecimal qty = ing.quantity != null ? ing.quantity : BigDecimal.ONE;
+                String name = ing.name != null ? ing.name.trim() : "";
+                String prepNote = ing.prepNote != null && !ing.prepNote.isBlank() ? ing.prepNote.trim() : null;
+                String section = ing.section != null && !ing.section.isBlank() ? ing.section.trim() : null;
+
+                if (name.isEmpty()) continue;
+
+                String rawText = qty.stripTrailingZeros().toPlainString() + " " + unit + " " + name;
+                ingredients.add(new ImportedIngredientPreview(section, name, qty, unit, rawText, prepNote));
+            }
+
+            String enrichedInstructions = llm.instructions;
+            return new ParsedIngredientResult(ingredients, enrichedInstructions);
+        } catch (Exception e) {
+            log.warn("Failed to parse LLM ingredient response: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    // Result type
+    public record ParsedIngredientResult(
+            List<ImportedIngredientPreview> ingredients,
+            String enrichedInstructions
+    ) {}
+
+    // LLM response DTOs
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record LlmParseResponse(
+            List<LlmParsedIngredient> ingredients,
+            String instructions
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record LlmParsedIngredient(
+            String name,
+            BigDecimal quantity,
+            String unit,
+            String section,
+            String prepNote,
+            Integer rawIndex
+    ) {}
+}

--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -36,40 +36,66 @@ public class OllamaRecipeExtractor {
 
     private static final String RECIPE_SCHEMA = """
             {
-              "name": "Recipe title",
-              "baseServings": 4,
-              "instructions": "1. First step...\\n2. Second step...",
-              "ingredients": [
-                {"section": "optional section name or null", "name": "ingredient name", "quantity": 2.5, "unit": "CUP"}
+              "recipes": [
+                {
+                  "name": "Recipe title",
+                  "baseServings": 4,
+                  "instructions": "1. First step...\\n2. Second step...",
+                  "ingredients": [
+                    {"section": "optional section name or null", "name": "ingredient name", "quantity": 2.5, "unit": "CUP", "prepNote": "optional prep note or null"}
+                  ]
+                }
               ]
             }""";
 
     private static final String RULES = """
             Rules:
-            - Valid units: TSP, TBSP, CUP, PINT, QUART, GALLON, HALF_GALLON, FL_OZ, WHOLE, LBS, OZ, PINCH, PIECE
+            - This image/text may contain ONE or MULTIPLE recipes — return ALL of them in the recipes array
+            - Recipes may be FULLY HANDWRITTEN — read all handwritten text carefully as recipe content
+            - Only ignore handwritten text that is clearly a marginal annotation on a PRINTED recipe (checkmarks, "good!", crossed-out alternatives)
+            - Two-column ingredient lists: read left column top-to-bottom, then right column top-to-bottom (do NOT read across rows)
+            - Sub-recipe sections: look for "For the X:", "Dough:", "Filling:", "Sauce:", "Marinade:", "Frosting:", "Topping:", "Crust:", "Glaze:" — use the label as the section field to group ingredients
+            - Valid units: TSP, TBSP, CUP, PINT, QUART, GALLON, HALF_GALLON, FL_OZ, WHOLE, LBS, OZ, PINCH, PIECE, G, ML, KG, L
+            - Common abbreviations: c./C. = CUP, lb./lbs. = LBS, tsp./t. = TSP, tbsp./T. = TBSP, oz. = OZ, pkg. = PIECE, env. = PIECE, pt. = PINT, qt. = QUART
             - Use WHOLE for items counted by number (e.g., "3 eggs" -> quantity 3, unit WHOLE)
             - Use PINCH for "doonks", dashes, or pinches
+            - NAME = shopping-list item. Strip ALL prep verbs (peeled, chopped, minced, sliced, diced, grated, beaten, etc.)
+            - PREP NOTE = preparation guidance stripped from the name (e.g., "grated", "peeled and left whole", "beaten")
             - Convert unicode fractions to decimals (1/2=0.5, 1/4=0.25, 3/4=0.75, 1/3=0.333, 2/3=0.667)
-            - For ranges like "3 to 4 tablespoons", use the higher value
-            - Group ingredients by section if the recipe has labeled sections (e.g., "Sauce", "Marinade")
+            - For ranges like "3/4-1 cup" or "3 to 4 tablespoons", use the higher value
             - Number each instruction step
             - Do NOT include serving suggestions, family meal ideas, or non-recipe text in instructions
+            - Ignore page numbers, book headers/footers, source attributions, and copyright notices
             - Return ONLY valid JSON, no markdown fences or extra text""";
 
     private static final String VISION_PROMPT = """
-            You are a recipe extraction assistant. Analyze this photo of a recipe and extract the following as JSON:
+            You are a recipe extraction assistant. Analyze this photo of a recipe card or page and extract ALL recipes as JSON.
+
+            Visual guidance:
+            - The recipe may be HANDWRITTEN, PRINTED, or a mix — read ALL text as recipe content
+            - Only ignore handwritten text that is clearly a marginal annotation on a printed recipe (checkmarks, "good!", crossed-out alternatives)
+            - The image may be ROTATED 90° or upside down — orient yourself by finding the recipe title first
+            - If ingredients are in two columns, read the LEFT column top-to-bottom first, then the RIGHT column
+            - Look for sub-recipe section headers like "For the Dough:", "Filling:", "Sauce:" — group ingredients under these sections
+            - Recipe title is usually in larger, bold, or underlined text at the top
+            - For handwritten text, common abbreviations: c=cup, t/tsp=teaspoon, T/tbsp=tablespoon, lb=pound, oz=ounce, pkg=package
+            - "Makes X" or "Serves X" indicates baseServings
             """ + RECIPE_SCHEMA + "\n\n" + RULES;
 
     private static final String TEXT_PROMPT_PREFIX = """
             You are a recipe extraction assistant. The following is raw OCR text from a scanned recipe photo. \
-            The OCR may contain errors, merged lines, or text from multiple columns. Extract the recipe as JSON:
+            The OCR may contain errors, merged lines, or text from multiple columns. Extract ALL recipes as JSON:
             """ + RECIPE_SCHEMA + "\n\n" + RULES + """
 
             Additional rules for OCR cleanup:
             - Separate ingredients from instructions even if they are merged in the text
-            - Fix obvious OCR errors (e.g., "cuo" -> "cup", "tep" -> "tsp", "1/2" misread as "V2")
-            - Ignore page numbers, book headers/footers, and non-recipe text
-            - If the recipe name seems truncated or garbled, infer it from context
+            - Common OCR character errors: "l"/"I" misread as "1" or vice versa (e.g., "l cup"="1 cup"), "0"/"O" swapped (e.g., "35O"="350"), "rn" misread as "m", "cl" misread as "d"
+            - Common OCR word errors: "cuo"="cup", "tep"="tsp", "tbep"="tbsp", "fiour"="flour", "saIt"="salt", "buiter"="butter", "suqar"="sugar"
+            - Fraction misreads: "V2"="1/2", "VA"="1/4" — also handle unicode fractions
+            - Two-column merge detection: if a line has two quantities (e.g., "2 cups flour 1 tsp salt"), it is likely two ingredients merged from side-by-side columns — split them
+            - Look for sub-recipe sections: "For the Dough:", "Filling:", "Sauce:", "Marinade:" — use as section field
+            - Ignore page numbers, book headers/footers, source attributions, and non-recipe text
+            - If a recipe name seems truncated or garbled, infer it from context
 
             OCR Text:
             """;
@@ -77,9 +103,9 @@ public class OllamaRecipeExtractor {
     public OllamaRecipeExtractor(
             @Value("${ollama.host:}") String host,
             @Value("${ollama.port:11434}") int port,
-            @Value("${ollama.vision-model:qwen3-vl:8b}") String visionModel,
-            @Value("${ollama.text-model:qwen2.5:14b}") String textModel,
-            @Value("${ollama.timeout:120}") int timeout,
+            @Value("${ollama.vision-model:qwen2.5vl:7b}") String visionModel,
+            @Value("${ollama.text-model:qwen2.5:32b-instruct-q4_K_M}") String textModel,
+            @Value("${ollama.timeout:180}") int timeout,
             ObjectMapper objectMapper,
             RecipeImportService recipeImportService) {
         this.baseUrl = host.isBlank() ? "" : "http://" + host + ":" + port;
@@ -109,35 +135,33 @@ public class OllamaRecipeExtractor {
         }
     }
 
-    public ImportedRecipePreview extractFromImage(byte[] imageBytes, String mimeType) {
-        if (baseUrl.isBlank()) return null;
+    public List<ImportedRecipePreview> extractFromImage(byte[] imageBytes, String mimeType) {
+        if (baseUrl.isBlank()) return List.of();
         try {
             String base64 = Base64.getEncoder().encodeToString(imageBytes);
-            String mediaType = mimeType != null ? mimeType : "image/jpeg";
 
-            // Build OpenAI-compatible multimodal message
-            Map<String, Object> imageUrl = Map.of(
-                    "url", "data:" + mediaType + ";base64," + base64);
-            List<Map<String, Object>> content = List.of(
-                    Map.of("type", "text", "text", VISION_PROMPT),
-                    Map.of("type", "image_url", "image_url", imageUrl));
-            Map<String, Object> message = Map.of("role", "user", "content", content);
+            // Native Ollama API uses "images" array with raw base64 (no data URI prefix)
+            Map<String, Object> message = Map.of(
+                    "role", "user",
+                    "content", VISION_PROMPT,
+                    "images", List.of(base64));
             Map<String, Object> body = Map.of(
                     "model", visionModel,
                     "messages", List.of(message),
-                    "temperature", 0.1,
-                    "max_tokens", 4096);
+                    "stream", false,
+                    "think", false,
+                    "options", Map.of("temperature", 0.1, "num_predict", 8192));
 
             String json = callOllama(body);
             return parseResponse(json);
         } catch (Exception e) {
             log.warn("Vision extraction failed: {}", e.getMessage());
-            return null;
+            return List.of();
         }
     }
 
-    public ImportedRecipePreview extractFromText(String ocrText) {
-        if (baseUrl.isBlank()) return null;
+    public List<ImportedRecipePreview> extractFromText(String ocrText) {
+        if (baseUrl.isBlank()) return List.of();
         try {
             Map<String, Object> message = Map.of(
                     "role", "user",
@@ -145,22 +169,24 @@ public class OllamaRecipeExtractor {
             Map<String, Object> body = Map.of(
                     "model", textModel,
                     "messages", List.of(message),
-                    "temperature", 0.1,
-                    "max_tokens", 4096);
+                    "stream", false,
+                    "think", false,
+                    "options", Map.of("temperature", 0.1, "num_predict", 8192));
 
             String json = callOllama(body);
             return parseResponse(json);
         } catch (Exception e) {
             log.warn("Text extraction failed: {}", e.getMessage());
-            return null;
+            return List.of();
         }
     }
 
     private String callOllama(Map<String, Object> body) throws Exception {
         String requestBody = objectMapper.writeValueAsString(body);
+        log.debug("Calling Ollama native API: {}", baseUrl + "/api/chat");
 
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(baseUrl + "/v1/chat/completions"))
+                .uri(URI.create(baseUrl + "/api/chat"))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                 .timeout(Duration.ofSeconds(timeout))
@@ -171,48 +197,124 @@ public class OllamaRecipeExtractor {
             throw new RuntimeException("Ollama returned " + response.statusCode() + ": " + response.body());
         }
 
-        // Extract content from OpenAI-format response
         JsonNode root = objectMapper.readTree(response.body());
-        return root.at("/choices/0/message/content").asText();
+        JsonNode message = root.path("message");
+
+        // Primary: read from content field
+        String text = message.path("content").asText("").strip();
+        if (!text.isEmpty()) return text;
+
+        // Fallback: Qwen3 thinking models put chain-of-thought in "thinking" field
+        // and may leave content empty — try to extract JSON from thinking
+        String thinking = message.path("thinking").asText("").strip();
+        if (!thinking.isEmpty()) {
+            log.warn("Content field empty, attempting to extract JSON from thinking field ({} chars)", thinking.length());
+            return extractJsonFromThinking(thinking);
+        }
+
+        throw new RuntimeException("Ollama response had empty content and no thinking field");
     }
 
-    private ImportedRecipePreview parseResponse(String content) {
-        // Strip markdown fences if present
+    private String extractJsonFromThinking(String text) {
+        // Find the last top-level { ... } block (likely the final JSON answer)
+        int depth = 0;
+        int lastObjStart = -1;
+        int lastObjEnd = -1;
+        boolean inString = false;
+
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '"' && (i == 0 || text.charAt(i - 1) != '\\')) {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == '{') {
+                    if (depth == 0) lastObjStart = i;
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                    if (depth == 0 && lastObjStart >= 0) {
+                        lastObjEnd = i + 1;
+                    }
+                }
+            }
+        }
+
+        if (lastObjStart >= 0 && lastObjEnd > lastObjStart) {
+            return text.substring(lastObjStart, lastObjEnd);
+        }
+
+        throw new RuntimeException("No JSON object found in thinking text");
+    }
+
+    List<ImportedRecipePreview> parseResponse(String content) {
         String json = content.strip();
         if (json.startsWith("```")) {
             json = json.replaceFirst("^```(?:json)?\\s*", "").replaceFirst("\\s*```$", "");
         }
 
-        LlmRecipeResponse llm;
+        List<ImportedRecipePreview> results = new ArrayList<>();
+
+        // Try multi-recipe format first
         try {
-            llm = objectMapper.readValue(json, LlmRecipeResponse.class);
+            LlmMultiRecipeResponse multi = objectMapper.readValue(json, LlmMultiRecipeResponse.class);
+            if (multi.recipes != null && !multi.recipes.isEmpty()) {
+                for (LlmRecipeResponse recipe : multi.recipes) {
+                    ImportedRecipePreview preview = buildPreview(recipe);
+                    if (preview != null) results.add(preview);
+                }
+                return results;
+            }
+        } catch (Exception ignored) {
+            // Fall through to single-recipe format
+        }
+
+        // Fall back to single-recipe format (backward compatibility)
+        try {
+            LlmRecipeResponse single = objectMapper.readValue(json, LlmRecipeResponse.class);
+            ImportedRecipePreview preview = buildPreview(single);
+            if (preview != null) results.add(preview);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new RuntimeException("Failed to parse LLM response as recipe JSON", e);
         }
 
-        List<ImportedIngredientPreview> ingredients = new ArrayList<>();
-        for (LlmIngredient ing : llm.ingredients) {
-            // Use existing fuzzy unit matching from RecipeImportService
-            String unit = ing.unit != null ? ing.unit.toUpperCase() : "WHOLE";
-            ImportedIngredientPreview parsed = recipeImportService.parseIngredientText(
-                    ing.quantity + " " + unit + " " + ing.name);
+        return results;
+    }
 
-            // Override with LLM values (more reliable than re-parsing)
-            ingredients.add(new ImportedIngredientPreview(
-                    ing.section,
-                    ing.name,
-                    ing.quantity != null ? ing.quantity : parsed.quantity(),
-                    unit,
-                    ing.quantity + " " + unit + " " + ing.name));
+    private ImportedRecipePreview buildPreview(LlmRecipeResponse llm) {
+        if (llm == null || llm.name == null || llm.name.isBlank()) return null;
+
+        List<ImportedIngredientPreview> ingredients = new ArrayList<>();
+        if (llm.ingredients != null) {
+            for (LlmIngredient ing : llm.ingredients) {
+                String unit = ing.unit != null ? ing.unit.toUpperCase() : "WHOLE";
+                String name = ing.name != null ? ing.name.trim() : "";
+                if (name.isBlank()) continue;
+
+                BigDecimal quantity = ing.quantity != null ? ing.quantity : BigDecimal.ONE;
+                String rawText = quantity + " " + unit + " " + name;
+
+                ingredients.add(new ImportedIngredientPreview(
+                        ing.section,
+                        name,
+                        quantity,
+                        unit,
+                        rawText,
+                        ing.prepNote));
+            }
         }
 
         return new ImportedRecipePreview(
                 llm.name,
-                llm.instructions,
+                llm.instructions != null ? llm.instructions : "",
                 llm.baseServings > 0 ? llm.baseServings : 1,
                 ingredients,
                 "scan");
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record LlmMultiRecipeResponse(
+            List<LlmRecipeResponse> recipes
+    ) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record LlmRecipeResponse(
@@ -227,6 +329,7 @@ public class OllamaRecipeExtractor {
             String section,
             String name,
             BigDecimal quantity,
-            String unit
+            String unit,
+            String prepNote
     ) {}
 }

--- a/src/main/java/com/endoran/foodplan/service/RecipeImportService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeImportService.java
@@ -10,8 +10,11 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +23,8 @@ import java.util.regex.Pattern;
 
 @Service
 public class RecipeImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(RecipeImportService.class);
 
     private static final Pattern QTY_PATTERN = Pattern.compile(
             "^\\s*(\\d+\\s+\\d+/\\d+|\\d+(?:[./]\\d+)?)\\s*");
@@ -60,13 +65,20 @@ public class RecipeImportService {
             Map.entry("pound", "LBS"), Map.entry("pounds", "LBS"), Map.entry("lb", "LBS"),
             Map.entry("lbs", "LBS"), Map.entry("1b", "LBS"), Map.entry("1bs", "LBS"),
             Map.entry("ibs", "LBS"), Map.entry("ib", "LBS"),
-            // Can
+            // Can → WHOLE
             Map.entry("can", "WHOLE"), Map.entry("cans", "WHOLE"),
             // Pinch
             Map.entry("pinch", "PINCH"),
             // Piece
             Map.entry("piece", "PIECE"), Map.entry("pieces", "PIECE"),
-            // Descriptive units
+            // Metric
+            Map.entry("g", "G"), Map.entry("gram", "G"), Map.entry("grams", "G"),
+            Map.entry("ml", "ML"), Map.entry("milliliter", "ML"), Map.entry("milliliters", "ML"),
+            Map.entry("millilitre", "ML"), Map.entry("millilitres", "ML"),
+            Map.entry("kg", "KG"), Map.entry("kilogram", "KG"), Map.entry("kilograms", "KG"),
+            Map.entry("l", "L"), Map.entry("liter", "L"), Map.entry("liters", "L"),
+            Map.entry("litre", "L"), Map.entry("litres", "L"),
+            // Descriptive units → WHOLE
             Map.entry("whole", "WHOLE"), Map.entry("large", "WHOLE"), Map.entry("medium", "WHOLE"),
             Map.entry("small", "WHOLE"), Map.entry("clove", "WHOLE"), Map.entry("cloves", "WHOLE"),
             Map.entry("bulb", "WHOLE"), Map.entry("bunch", "WHOLE"), Map.entry("head", "WHOLE"),
@@ -85,11 +97,57 @@ public class RecipeImportService {
                 Pattern.CASE_INSENSITIVE);
     }
 
+    // Number words for descriptive prefixes like "One 3-pound chuck roast"
+    private static final Map<String, Integer> NUMBER_WORDS = Map.ofEntries(
+            Map.entry("one", 1), Map.entry("two", 2), Map.entry("three", 3),
+            Map.entry("four", 4), Map.entry("five", 5), Map.entry("six", 6),
+            Map.entry("seven", 7), Map.entry("eight", 8), Map.entry("nine", 9),
+            Map.entry("ten", 10), Map.entry("eleven", 11), Map.entry("twelve", 12),
+            Map.entry("a", 1), Map.entry("an", 1)
+    );
+
+    // Pre-processing patterns
+    private static final Pattern DASH_FRACTION = Pattern.compile("(\\d+)-(\\d+/\\d+)");
+    private static final Pattern RANGE_WITH_UNIT = Pattern.compile(
+            "(\\d+(?:\\s+\\d+/\\d+|[./]\\d+)?)-?\\s*to\\s*(\\d+(?:\\s+\\d+/\\d+|[./]\\d+)?)\\s*[- ]?(\\w+)");
+    private static final Pattern RANGE_SIMPLE = Pattern.compile(
+            "(\\d+(?:\\.\\d+)?)\\s+to\\s+(\\d+(?:\\.\\d+)?)(?=\\s)");
+    private static final Pattern PAREN_MEASUREMENT = Pattern.compile(
+            "\\((\\d+(?:[- ]\\d+/\\d+|[./]\\d+)?)\\s*-?\\s*(ounces?|oz|pounds?|lbs?|grams?|g)\\)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern SECTION_HEADER = Pattern.compile("^([A-Z][A-Z ]+):$");
+    private static final Pattern NUMBER_WORD_PREFIX = Pattern.compile(
+            "^(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a|an)\\s+",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern DUAL_UNIT = Pattern.compile(
+            "(\\d+(?:\\s+\\d+/\\d+|[./]\\d+)?)\\s*(cups?|tablespoons?|teaspoons?)/(\\d+)\\s*(grams?|g|ml|oz|ounces?)\\s+",
+            Pattern.CASE_INSENSITIVE);
+
+    // Post-processing patterns
+    private static final Pattern PLUS_MINUS_MOD = Pattern.compile(
+            "\\s*(?:plus|minus)\\s+(?:\\d+(?:\\s+\\d+/\\d+)?\\s+(?:tablespoons?|teaspoons?|cups?|tbsp\\.?|tsp\\.?)\\s*(?:for\\s+\\w+(?:\\s+\\w+)*)?|(?:a\\s+)?(?:little|more|extra)\\b.*)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern PAREN_ALT_MEASURE = Pattern.compile(
+            "\\((?:\\d+[^)]*(?:ounces?|sticks?|grams?|g|oz|lbs?|pounds?|cups?|ml)|such as[^)]*|or [^)]*)\\)?",
+            Pattern.CASE_INSENSITIVE);
+    // Strips "Brand1 or qty unit Brand2" leaving just the ingredient type at the end
+    // e.g. "Diamond Crystal or 1/2 tsp. Morton kosher salt" → "kosher salt"
+    private static final Pattern BRAND_ALTERNATIVE = Pattern.compile(
+            "(?:Diamond Crystal|Morton)\\s+or\\s+(?:\\d+(?:\\s+\\d+/\\d+|/\\d+)?\\s*(?:tsp\\.?|tbsp\\.?|teaspoons?|tablespoons?)\\s*\\.?\\s*)?(?:Diamond Crystal|Morton)\\s+",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern PACKAGE_DESC = Pattern.compile(
+            "^package\\s+", Pattern.CASE_INSENSITIVE);
+
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OllamaIngredientParser ollamaIngredientParser;
+
+    public RecipeImportService(OllamaIngredientParser ollamaIngredientParser) {
+        this.ollamaIngredientParser = ollamaIngredientParser;
+    }
 
     public ImportedRecipePreview importFromUrl(String url) throws IOException {
         Document doc = Jsoup.connect(url)
-                .userAgent("FoodPlan/1.0")
+                .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                 .timeout(10_000)
                 .get();
 
@@ -133,12 +191,45 @@ public class RecipeImportService {
         if (!type.equalsIgnoreCase("Recipe")) return null;
 
         String name = node.path("name").asText("Untitled Recipe");
+        String instructions = extractInstructions(node);
+        int servings = extractServings(node);
 
-        // Instructions
-        String instructions = "";
+        // Extract raw ingredient strings
+        List<String> rawIngredientStrings = new ArrayList<>();
+        JsonNode ingredientNode = node.path("recipeIngredient");
+        if (ingredientNode.isArray()) {
+            for (JsonNode ing : ingredientNode) {
+                String raw = ing.asText("").trim();
+                if (!raw.isEmpty()) rawIngredientStrings.add(raw);
+            }
+        }
+
+        // Try LLM-powered parsing first
+        if (ollamaIngredientParser.isAvailable()) {
+            try {
+                OllamaIngredientParser.ParsedIngredientResult llmResult =
+                        ollamaIngredientParser.parseIngredients(rawIngredientStrings, instructions);
+                if (llmResult != null && !llmResult.ingredients().isEmpty()) {
+                    log.info("LLM parsed {} ingredients from {} raw inputs", llmResult.ingredients().size(), rawIngredientStrings.size());
+                    String enrichedInstructions = llmResult.enrichedInstructions() != null
+                            ? llmResult.enrichedInstructions() : instructions;
+                    return new ImportedRecipePreview(name, enrichedInstructions, servings,
+                            llmResult.ingredients(), url);
+                }
+            } catch (Exception e) {
+                log.warn("LLM ingredient parsing failed, using regex fallback: {}", e.getMessage());
+            }
+        }
+
+        // Regex fallback
+        List<ImportedIngredientPreview> ingredients = parseIngredientsWithRegex(rawIngredientStrings);
+        return new ImportedRecipePreview(name, instructions, servings, ingredients, url);
+    }
+
+    private String extractInstructions(JsonNode node) {
         JsonNode instructionNode = node.path("recipeInstructions");
         if (instructionNode.isTextual()) {
-            instructions = instructionNode.asText();
+            return instructionNode.asText();
         } else if (instructionNode.isArray()) {
             List<String> steps = new ArrayList<>();
             int stepNum = 1;
@@ -149,84 +240,216 @@ public class RecipeImportService {
                     steps.add(stepNum++ + ". " + step.path("text").asText());
                 }
             }
-            instructions = String.join("\n", steps);
+            return String.join("\n", steps);
         }
+        return "";
+    }
 
-        // Servings
-        int servings = 1;
+    private int extractServings(JsonNode node) {
         JsonNode yieldNode = node.path("recipeYield");
         if (yieldNode.isTextual()) {
             Matcher m = Pattern.compile("(\\d+)").matcher(yieldNode.asText());
-            if (m.find()) servings = Integer.parseInt(m.group(1));
+            if (m.find()) return Integer.parseInt(m.group(1));
         } else if (yieldNode.isArray() && !yieldNode.isEmpty()) {
             Matcher m = Pattern.compile("(\\d+)").matcher(yieldNode.get(0).asText());
-            if (m.find()) servings = Integer.parseInt(m.group(1));
+            if (m.find()) return Integer.parseInt(m.group(1));
         } else if (yieldNode.isNumber()) {
-            servings = yieldNode.asInt(1);
+            return yieldNode.asInt(1);
         }
+        return 1;
+    }
 
-        // Ingredients
+    private List<ImportedIngredientPreview> parseIngredientsWithRegex(List<String> rawIngredientStrings) {
         List<ImportedIngredientPreview> ingredients = new ArrayList<>();
-        JsonNode ingredientNode = node.path("recipeIngredient");
-        if (ingredientNode.isArray()) {
-            for (JsonNode ing : ingredientNode) {
-                String raw = ing.asText("").trim();
-                if (!raw.isEmpty()) {
-                    ingredients.add(parseIngredientText(raw));
-                }
+        String currentSection = null;
+        for (String raw : rawIngredientStrings) {
+            String detectedSection = detectSection(raw);
+            if (detectedSection != null) {
+                currentSection = detectedSection;
+                continue;
             }
-        }
 
-        return new ImportedRecipePreview(name, instructions, servings, ingredients, url);
+            ImportedIngredientPreview parsed = parseIngredientText(raw);
+            if (currentSection != null && (parsed.section() == null || parsed.section().isEmpty())) {
+                parsed = new ImportedIngredientPreview(currentSection, parsed.name(), parsed.quantity(),
+                        parsed.unit(), parsed.rawText(), parsed.prepNote());
+            }
+            ingredients.add(parsed);
+        }
+        return ingredients;
+    }
+
+    private String detectSection(String raw) {
+        // "FROSTING:", "FOR THE SAUCE:", "Topping:"
+        Matcher m = SECTION_HEADER.matcher(raw.trim());
+        if (m.matches()) return titleCase(m.group(1));
+
+        // "For the X:" pattern
+        if (raw.trim().matches("(?i)^for\\s+(the\\s+)?\\w[\\w ]*:$")) {
+            String section = raw.trim().replaceFirst("(?i)^for\\s+(the\\s+)?", "").replaceAll(":$", "").trim();
+            return titleCase(section);
+        }
+        return null;
+    }
+
+    private static String titleCase(String s) {
+        if (s == null || s.isEmpty()) return s;
+        StringBuilder sb = new StringBuilder();
+        for (String word : s.toLowerCase().split("\\s+")) {
+            if (!sb.isEmpty()) sb.append(' ');
+            sb.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+        }
+        return sb.toString();
     }
 
     ImportedIngredientPreview parseIngredientText(String raw) {
-        String normalized = normalizeUnicodeFractions(raw);
-        BigDecimal quantity = BigDecimal.ONE;
-        String unit = "WHOLE";
-        String ingredientName = normalized;
+        // Step 1: Unicode fractions
+        String text = normalizeUnicodeFractions(raw);
 
-        // Extract quantity
-        Matcher qtyMatcher = QTY_PATTERN.matcher(normalized);
-        if (qtyMatcher.find()) {
-            String qtyStr = qtyMatcher.group(1);
-            quantity = parseFraction(qtyStr);
-            ingredientName = normalized.substring(qtyMatcher.end()).trim();
+        // Step 2: Normalize dash-fractions: "2-2/3" → "2 2/3"
+        text = DASH_FRACTION.matcher(text).replaceAll("$1 $2");
+
+        // Step 3: Handle dual unit formats: "3 1/3 cups/430 grams flour" → take first unit
+        Matcher dualMatcher = DUAL_UNIT.matcher(text);
+        if (dualMatcher.find()) {
+            text = dualMatcher.group(1) + " " + dualMatcher.group(2) + " " + text.substring(dualMatcher.end());
         }
 
-        // Extract unit (exact match via regex)
-        Matcher unitMatcher = UNIT_PATTERN.matcher(normalized);
-        if (unitMatcher.find()) {
-            String matchedUnit = unitMatcher.group(1).toLowerCase();
-            unit = UNIT_ALIASES.getOrDefault(matchedUnit, "WHOLE");
-            ingredientName = normalized.substring(unitMatcher.end()).trim();
-        } else if (qtyMatcher.hitEnd() || qtyMatcher.find(0)) {
-            // Fuzzy fallback: check if the first word after quantity is close to a known unit
-            String afterQty = ingredientName;
-            String[] words = afterQty.split("\\s+", 2);
-            if (words.length >= 1 && !words[0].isEmpty()) {
-                String candidate = words[0].toLowerCase().replaceAll("\\.$", "");
-                String fuzzyMatch = fuzzyMatchUnit(candidate);
-                if (fuzzyMatch != null) {
-                    unit = fuzzyMatch;
-                    ingredientName = words.length > 1 ? words[1].trim() : "";
+        // Step 4: Handle parenthetical measurements: "(28-ounce)" or "(14-1/2 ounces)"
+        // If the text starts with qty + paren measurement, extract it as the primary measurement
+        Matcher parenMatcher = PAREN_MEASUREMENT.matcher(text);
+        String parenQty = null;
+        String parenUnit = null;
+        if (parenMatcher.find()) {
+            parenQty = parenMatcher.group(1).replace("-", " ").replace("  ", " ");
+            parenUnit = parenMatcher.group(2).toLowerCase();
+            // Remove the parenthetical from text
+            text = text.substring(0, parenMatcher.start()) + text.substring(parenMatcher.end());
+            text = text.replaceAll("\\s{2,}", " ").trim();
+        }
+
+        // Step 5: Ranges — "3- to 5-pound" → "4 pound", "6 to 8 whole" → "7"
+        Matcher rangeMatcher = RANGE_WITH_UNIT.matcher(text);
+        if (rangeMatcher.find()) {
+            BigDecimal low = parseFraction(rangeMatcher.group(1).trim());
+            BigDecimal high = parseFraction(rangeMatcher.group(2).trim());
+            BigDecimal mid = low.add(high).divide(BigDecimal.valueOf(2), 2, RoundingMode.HALF_UP);
+            String midStr = mid.stripTrailingZeros().toPlainString();
+            text = text.substring(0, rangeMatcher.start()) + midStr + " " + rangeMatcher.group(3) + text.substring(rangeMatcher.end());
+        } else {
+            Matcher simpleRange = RANGE_SIMPLE.matcher(text);
+            if (simpleRange.find()) {
+                BigDecimal low = parseFraction(simpleRange.group(1).trim());
+                BigDecimal high = parseFraction(simpleRange.group(2).trim());
+                BigDecimal mid = low.add(high).divide(BigDecimal.valueOf(2), 2, RoundingMode.HALF_UP);
+                String midStr = mid.stripTrailingZeros().toPlainString();
+                text = text.substring(0, simpleRange.start()) + midStr + text.substring(simpleRange.end());
+            }
+        }
+
+        // Step 6: Number word prefixes: "One 3-pound" → "3 pound"
+        Matcher numWord = NUMBER_WORD_PREFIX.matcher(text);
+        if (numWord.find()) {
+            String word = numWord.group(1).toLowerCase();
+            if (NUMBER_WORDS.containsKey(word)) {
+                String rest = text.substring(numWord.end()).trim();
+                // If rest starts with a number+unit (like "3-pound"), use that
+                if (rest.matches("^\\d+.*")) {
+                    text = rest;
+                } else {
+                    // "One bay leaf" → "1 bay leaf"
+                    text = NUMBER_WORDS.get(word) + " " + rest;
                 }
             }
         }
 
-        // Clean up ingredient name
+        // Step 7: Extract quantity
+        BigDecimal quantity = BigDecimal.ONE;
+        String ingredientName = text;
+
+        Matcher qtyMatcher = QTY_PATTERN.matcher(text);
+        if (qtyMatcher.find()) {
+            String qtyStr = qtyMatcher.group(1);
+            quantity = parseFraction(qtyStr);
+            ingredientName = text.substring(qtyMatcher.end()).trim();
+        } else if (parenQty != null) {
+            // Use parenthetical quantity if no leading quantity found
+            quantity = parseFraction(parenQty);
+        }
+
+        // Step 8: Extract unit
+        String unit = "WHOLE";
+        Matcher unitMatcher = UNIT_PATTERN.matcher(text);
+        if (unitMatcher.find()) {
+            String matchedUnit = unitMatcher.group(1).toLowerCase().replaceAll("\\.$", "");
+            unit = UNIT_ALIASES.getOrDefault(matchedUnit, "WHOLE");
+            ingredientName = text.substring(unitMatcher.end()).trim();
+        } else {
+            // Try unit from the word immediately after the quantity
+            String[] words = ingredientName.split("\\s+", 2);
+            if (words.length >= 1 && !words[0].isEmpty()) {
+                String candidate = words[0].toLowerCase().replaceAll("\\.$", "");
+                // Exact match first
+                String exactMatch = UNIT_ALIASES.get(candidate);
+                if (exactMatch != null) {
+                    unit = exactMatch;
+                    ingredientName = words.length > 1 ? words[1].trim() : "";
+                } else {
+                    // Fuzzy match (but only for non-ambiguous candidates)
+                    String fuzzyMatch = fuzzyMatchUnit(candidate);
+                    if (fuzzyMatch != null) {
+                        unit = fuzzyMatch;
+                        ingredientName = words.length > 1 ? words[1].trim() : "";
+                    }
+                }
+            }
+        }
+
+        // If we had a parenthetical measurement and no better unit was found, use it
+        if (parenQty != null && "WHOLE".equals(unit) && parenUnit != null) {
+            quantity = parseFraction(parenQty);
+            String resolvedUnit = UNIT_ALIASES.get(parenUnit);
+            if (resolvedUnit == null) resolvedUnit = UNIT_ALIASES.get(parenUnit.replaceAll("s$", ""));
+            if (resolvedUnit != null) unit = resolvedUnit;
+        }
+
+        // Step 9: Strip modifiers from name: "plus 2 tablespoons", "minus 2 tablespoons"
+        ingredientName = PLUS_MINUS_MOD.matcher(ingredientName).replaceAll("");
+
+        // Step 10: Enhanced name cleanup
         ingredientName = ingredientName
-                .replaceFirst("^/\\s*", "")           // strip alternate-description separator ("4lbs / 1 Whole...")
-                .replaceFirst("^\\d+(?:[./]\\d+)?\\s+", "") // strip second quantity after separator
-                .replaceAll("^of\\s+", "")
-                .replaceAll(",.*", "")                // strip prep notes after comma
-                .trim();
+                .replaceFirst("^/\\s*", "")
+                .replaceFirst("^\\d+(?:[./]\\d+)?\\s+", "")  // strip second qty after separator
+                .replaceAll("^of\\s+", "");
+
+        // Strip parenthetical alt measurements and notes
+        ingredientName = PAREN_ALT_MEASURE.matcher(ingredientName).replaceAll("");
+
+        // Strip brand alternatives: "Diamond Crystal or 1/2 tsp. Morton kosher salt" → "kosher salt"
+        ingredientName = BRAND_ALTERNATIVE.matcher(ingredientName).replaceAll("");
+
+        // Strip "package" descriptor (the size was already extracted)
+        ingredientName = PACKAGE_DESC.matcher(ingredientName).replaceAll("");
+
+        // Strip "for <prep purpose>" clauses
+        ingredientName = ingredientName.replaceAll("\\s+for\\s+(?:tossing|serving|garnish|frying|greasing|dusting|dipping|drizzling|topping|rolling)\\b.*", "");
+
+        // Strip comma-separated prep notes
+        ingredientName = ingredientName.replaceAll(",.*", "");
+
+        // Strip trailing "to serve", "to taste", "(optional)"
+        ingredientName = ingredientName.replaceAll("\\s+to\\s+(?:serve|taste)\\b.*", "");
+        ingredientName = ingredientName.replaceAll("\\s*\\(optional\\)\\s*", "");
+
+        // Clean up whitespace and leading/trailing punctuation
+        ingredientName = ingredientName.replaceAll("\\s{2,}", " ").trim();
+        ingredientName = ingredientName.replaceAll("^[\\s,;.]+|[\\s,;.]+$", "").trim();
 
         if (ingredientName.isEmpty()) {
             ingredientName = raw;
         }
 
-        return new ImportedIngredientPreview(null, ingredientName, quantity, unit, raw);
+        return new ImportedIngredientPreview(null, ingredientName, quantity, unit, raw, null);
     }
 
     private BigDecimal parseFraction(String s) {
@@ -247,7 +470,7 @@ public class RecipeImportService {
             String[] parts = s.split("/");
             if (parts.length == 2) {
                 try {
-                    return new BigDecimal(parts[0]).divide(new BigDecimal(parts[1]), 4, java.math.RoundingMode.HALF_UP);
+                    return new BigDecimal(parts[0]).divide(new BigDecimal(parts[1]), 4, RoundingMode.HALF_UP);
                 } catch (Exception e) {
                     return BigDecimal.ONE;
                 }
@@ -262,13 +485,14 @@ public class RecipeImportService {
 
     private String fuzzyMatchUnit(String candidate) {
         if (candidate.length() < 2 || candidate.length() > 12) return null;
-        // Allow distance 2 for longer words (5+ chars), distance 1 for short abbreviations
+        // Skip single-char candidates that could be ambiguous (avoid "g" fuzzy-matching "c")
+        // Single-char exact matches are handled above; fuzzy needs 3+ chars
+        if (candidate.length() < 3) return null;
         int maxDist = candidate.length() >= 5 ? 2 : 1;
         int bestDist = Integer.MAX_VALUE;
         String bestUnit = null;
         for (Map.Entry<String, String> entry : UNIT_ALIASES.entrySet()) {
             String alias = entry.getKey();
-            // Only fuzzy-match against aliases of similar length
             if (Math.abs(alias.length() - candidate.length()) > maxDist) continue;
             int dist = editDistance(candidate, alias);
             if (dist <= maxDist && dist < bestDist) {
@@ -299,7 +523,6 @@ public class RecipeImportService {
             char c = text.charAt(i);
             String replacement = UNICODE_FRACTIONS.get(c);
             if (replacement != null) {
-                // If preceded by a digit (e.g., "1½"), insert a space so it becomes "1 1/2"
                 if (sb.length() > 0 && Character.isDigit(sb.charAt(sb.length() - 1))) {
                     sb.append(' ');
                 }

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -179,22 +179,31 @@ public class RecipeScanService {
             BufferedImage img = ImageIO.read(new java.io.ByteArrayInputStream(imageBytes));
             if (img == null) return imageBytes;
 
+            boolean modified = false;
+
             // Use Tesseract OSD to detect text orientation
-            BufferedImage gray = preprocessForOcr(img);
-            BufferedImage corrected = detectAndFixRotation(gray);
-            if (corrected != gray) {
-                log.info("OSD detected rotation for vision — applying correction");
-                img = detectAndFixRotation(img);
+            int osdRotation = detectRotationDegrees(img);
+            if (osdRotation != 0) {
+                log.info("OSD detected {}° rotation for vision — correcting", osdRotation);
+                img = rotateImage(img, Math.toRadians(osdRotation));
+                modified = true;
             }
 
-            // Fallback: rotate landscape images
-            if (img.getWidth() > img.getHeight() * 1.2) {
+            // Fallback: rotate landscape images (only if OSD didn't already rotate)
+            if (!modified && img.getWidth() > img.getHeight() * 1.2) {
                 log.info("Auto-rotating landscape image {}x{} -> portrait for vision", img.getWidth(), img.getHeight());
                 img = rotateImage(img, Math.PI / 2);
+                modified = true;
             }
 
             // Downscale for vision model — Qwen2.5-VL works best at ~1568px max dimension
-            img = downscaleForVision(img, 1568);
+            int maxDim = Math.max(img.getWidth(), img.getHeight());
+            if (maxDim > 1568) {
+                img = downscaleForVision(img, 1568);
+                modified = true;
+            }
+
+            if (!modified) return imageBytes;
 
             java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
             String format = contentType != null && contentType.contains("png") ? "png" : "jpg";
@@ -330,11 +339,12 @@ public class RecipeScanService {
         }
     }
 
-    private BufferedImage detectAndFixRotation(BufferedImage image) {
+    private int detectRotationDegrees(BufferedImage image) {
         Path tempFile = null;
         try {
+            BufferedImage gray = preprocessForOcr(image);
             tempFile = Files.createTempFile("osd-", ".png");
-            ImageIO.write(image, "png", tempFile.toFile());
+            ImageIO.write(gray, "png", tempFile.toFile());
 
             ProcessBuilder pb = new ProcessBuilder(
                     "tesseract", tempFile.toString(), "stdout", "--psm", "0");
@@ -343,19 +353,22 @@ public class RecipeScanService {
             String output = new String(proc.getInputStream().readAllBytes());
             proc.waitFor();
 
-            int rotation = parseOsdRotation(output);
-            if (rotation != 0) {
-                log.info("OSD detected Rotate:{} — applying correction", rotation);
-                double radians = Math.toRadians(rotation);
-                return rotateImage(image, radians);
-            }
-            return image;
+            return parseOsdRotation(output);
         } catch (Exception e) {
             log.debug("OSD rotation detection failed (non-fatal): {}", e.getMessage());
-            return image;
+            return 0;
         } finally {
             try { if (tempFile != null) Files.deleteIfExists(tempFile); } catch (Exception ignored) {}
         }
+    }
+
+    private BufferedImage detectAndFixRotation(BufferedImage image) {
+        int rotation = detectRotationDegrees(image);
+        if (rotation != 0) {
+            log.info("OSD detected Rotate:{} — applying correction", rotation);
+            return rotateImage(image, Math.toRadians(rotation));
+        }
+        return image;
     }
 
     private int parseOsdRotation(String osdOutput) {

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -351,7 +351,12 @@ public class RecipeScanService {
             pb.redirectErrorStream(true);
             Process proc = pb.start();
             String output = new String(proc.getInputStream().readAllBytes());
-            proc.waitFor();
+            boolean finished = proc.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
+            if (!finished) {
+                proc.destroyForcibly();
+                log.debug("OSD process timed out after 10s");
+                return 0;
+            }
 
             return parseOsdRotation(output);
         } catch (Exception e) {

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -2,6 +2,9 @@ package com.endoran.foodplan.service;
 
 import com.endoran.foodplan.dto.ImportedIngredientPreview;
 import com.endoran.foodplan.dto.ImportedRecipePreview;
+import com.endoran.foodplan.dto.ScanResult;
+import com.endoran.foodplan.model.ScanSession;
+import com.endoran.foodplan.repository.ScanSessionRepository;
 import com.drew.imaging.ImageMetadataReader;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.exif.ExifIFD0Directory;
@@ -24,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 @Service
 public class RecipeScanService {
@@ -34,13 +40,10 @@ public class RecipeScanService {
             "(?:serves?|servings?|yield|makes?)\\s*:?\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern TIME_PATTERN = Pattern.compile(
             "(?:time|prep|cook)\\s*:?\\s*(\\d+)\\s*(?:min|hour|hr)", Pattern.CASE_INSENSITIVE);
-    // Recipe metadata lines to skip (common in printed/web recipes)
     private static final Pattern METADATA_PATTERN = Pattern.compile(
             "^(?:course|cuisine|keyword|category|author|calories|total\\s*time|prep\\s*time|cook\\s*time|" +
             "refrigerat\\w*|resting|cooling|nutrition|yield)\\b.*",
             Pattern.CASE_INSENSITIVE);
-    // Sub-section headers: lines with a colon like "For the Marinade:", "Sauce:"
-    // OR short all-letter lines (≤4 words, no digits) like "Soup", "Chicken Rub"
     private static final Pattern SUB_SECTION_WITH_COLON = Pattern.compile(
             "^(?:for\\s+)?(?:the\\s+)?[\\p{L} ]+:\\s*$", Pattern.CASE_INSENSITIVE);
     private static final Pattern SUB_SECTION_SHORT_LABEL = Pattern.compile(
@@ -48,23 +51,86 @@ public class RecipeScanService {
 
     private final RecipeImportService recipeImportService;
     private final OllamaRecipeExtractor ollamaExtractor;
+    private final ScanSessionRepository scanSessionRepository;
 
     public RecipeScanService(RecipeImportService recipeImportService,
-                             OllamaRecipeExtractor ollamaExtractor) {
+                             OllamaRecipeExtractor ollamaExtractor,
+                             ScanSessionRepository scanSessionRepository) {
         this.recipeImportService = recipeImportService;
         this.ollamaExtractor = ollamaExtractor;
+        this.scanSessionRepository = scanSessionRepository;
     }
 
-    public ImportedRecipePreview scanFile(MultipartFile file) {
+
+    private static boolean isHeic(MultipartFile file) {
+        String ct = file.getContentType();
+        if (ct != null && (ct.equals("image/heic") || ct.equals("image/heif"))) return true;
+        String name = file.getOriginalFilename();
+        return name != null && (name.toLowerCase().endsWith(".heic") || name.toLowerCase().endsWith(".heif"));
+    }
+
+    private byte[] convertHeicToJpeg(MultipartFile file) {
+        Path heicPath = null;
+        Path jpegPath = null;
+        try {
+            heicPath = Files.createTempFile("scan-", ".heic");
+            jpegPath = Path.of(heicPath.toString().replace(".heic", ".jpg"));
+            file.transferTo(heicPath);
+
+            ProcessBuilder pb = new ProcessBuilder("heif-convert", heicPath.toString(), jpegPath.toString());
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+            String output = new String(proc.getInputStream().readAllBytes());
+            int exit = proc.waitFor();
+            if (exit != 0) {
+                throw new RecipeImportException("HEIC conversion failed (exit " + exit + "): " + output);
+            }
+
+            log.info("Converted HEIC to JPEG ({} KB -> {} KB)",
+                    Files.size(heicPath) / 1024, Files.size(jpegPath) / 1024);
+            return Files.readAllBytes(jpegPath);
+        } catch (RecipeImportException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RecipeImportException("Failed to convert HEIC: " + e.getMessage(), e);
+        } finally {
+            try { if (heicPath != null) Files.deleteIfExists(heicPath); } catch (Exception ignored) {}
+            try { if (jpegPath != null) Files.deleteIfExists(jpegPath); } catch (Exception ignored) {}
+        }
+    }
+
+    public ScanResult scanFile(MultipartFile file, String orgId) {
+        // Convert HEIC/HEIF to JPEG before any processing
+        if (isHeic(file)) {
+            byte[] jpegBytes = convertHeicToJpeg(file);
+            file = new SimpleMultipartFile(file.getOriginalFilename() + ".jpg", "image/jpeg", jpegBytes);
+        }
+
+        // Capture image bytes for training pair storage
+        byte[] imageBytes;
+        String imageContentType = file.getContentType();
+        try {
+            imageBytes = file.getBytes();
+        } catch (IOException e) {
+            throw new RecipeImportException("Failed to read file: " + e.getMessage(), e);
+        }
+
+        // Auto-rotate landscape images for vision model (recipe cards are almost always portrait)
+        byte[] visionBytes = autoRotateForVision(imageBytes, imageContentType);
+
+        List<ImportedRecipePreview> recipes;
+        String tier;
+
         // Tier 1 & 2: Try LLM extraction if Ollama is available
         if (ollamaExtractor.isAvailable()) {
             // Tier 1: Vision — send photo directly to vision model
             try {
-                ImportedRecipePreview vision = ollamaExtractor.extractFromImage(
-                        file.getBytes(), file.getContentType());
-                if (vision != null) {
-                    log.info("Recipe extracted via vision LLM");
-                    return vision;
+                List<ImportedRecipePreview> vision = ollamaExtractor.extractFromImage(visionBytes, imageContentType);
+                if (!vision.isEmpty()) {
+                    log.info("Extracted {} recipe(s) via vision LLM", vision.size());
+                    recipes = vision;
+                    tier = "VISION";
+                    return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
                 }
             } catch (Exception e) {
                 log.warn("Vision extraction attempt failed: {}", e.getMessage());
@@ -72,21 +138,90 @@ public class RecipeScanService {
 
             // Tier 2: Text LLM — OCR first, then send text to LLM
             String ocrText = performOcr(file);
-            ImportedRecipePreview textLlm = ollamaExtractor.extractFromText(ocrText);
-            if (textLlm != null) {
-                log.info("Recipe extracted via text LLM (OCR + LLM)");
-                return textLlm;
+            List<ImportedRecipePreview> textLlm = ollamaExtractor.extractFromText(ocrText);
+            if (!textLlm.isEmpty()) {
+                log.info("Extracted {} recipe(s) via text LLM (OCR + LLM)", textLlm.size());
+                recipes = textLlm;
+                tier = "TEXT_LLM";
+                return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
             }
 
             // Tier 3: Regex fallback — reuse OCR text already captured
             log.info("Recipe extracted via regex fallback");
-            return parseScannedText(ocrText);
+            recipes = List.of(parseScannedText(ocrText));
+            tier = "REGEX";
+            return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
         }
 
         // Ollama not available — go straight to regex fallback
         log.info("Ollama unavailable, using regex fallback");
         String text = performOcr(file);
-        return parseScannedText(text);
+        recipes = List.of(parseScannedText(text));
+        tier = "REGEX";
+        return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
+    }
+
+    private ScanResult saveScanSession(String orgId, byte[] imageBytes, String imageContentType,
+                                        List<ImportedRecipePreview> recipes, String tier) {
+        ScanSession session = new ScanSession();
+        session.setOrgId(orgId);
+        session.setImageData(imageBytes);
+        session.setImageContentType(imageContentType);
+        session.setModelOutput(recipes);
+        session.setExtractionTier(tier);
+        session = scanSessionRepository.save(session);
+        log.info("Saved scan session {} (tier={}, recipes={})", session.getId(), tier, recipes.size());
+        return new ScanResult(session.getId(), recipes);
+    }
+
+    private byte[] autoRotateForVision(byte[] imageBytes, String contentType) {
+        try {
+            BufferedImage img = ImageIO.read(new java.io.ByteArrayInputStream(imageBytes));
+            if (img == null) return imageBytes;
+
+            // Use Tesseract OSD to detect text orientation
+            BufferedImage gray = preprocessForOcr(img);
+            BufferedImage corrected = detectAndFixRotation(gray);
+            if (corrected != gray) {
+                log.info("OSD detected rotation for vision — applying correction");
+                img = detectAndFixRotation(img);
+            }
+
+            // Fallback: rotate landscape images
+            if (img.getWidth() > img.getHeight() * 1.2) {
+                log.info("Auto-rotating landscape image {}x{} -> portrait for vision", img.getWidth(), img.getHeight());
+                img = rotateImage(img, Math.PI / 2);
+            }
+
+            // Downscale for vision model — Qwen2.5-VL works best at ~1568px max dimension
+            img = downscaleForVision(img, 1568);
+
+            java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            String format = contentType != null && contentType.contains("png") ? "png" : "jpg";
+            ImageIO.write(img, format, baos);
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.warn("Auto-rotation failed, using original: {}", e.getMessage());
+            return imageBytes;
+        }
+    }
+
+    private BufferedImage downscaleForVision(BufferedImage img, int maxDim) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        if (w <= maxDim && h <= maxDim) return img;
+
+        double scale = (double) maxDim / Math.max(w, h);
+        int nw = (int) (w * scale);
+        int nh = (int) (h * scale);
+        log.info("Downscaling image {}x{} -> {}x{} for vision model", w, h, nw, nh);
+        BufferedImage scaled = new BufferedImage(nw, nh, BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D g = scaled.createGraphics();
+        g.setRenderingHint(java.awt.RenderingHints.KEY_INTERPOLATION,
+                java.awt.RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        g.drawImage(img, 0, 0, nw, nh, null);
+        g.dispose();
+        return scaled;
     }
 
     String performOcr(MultipartFile file) {
@@ -126,10 +261,10 @@ public class RecipeScanService {
             log.info("EXIF orientation tag: {}", orientation);
 
             return switch (orientation) {
-                case 3 -> rotateImage(image, Math.PI);           // 180°
-                case 6 -> rotateImage(image, Math.PI / 2);       // 90° CW
-                case 8 -> rotateImage(image, -Math.PI / 2);      // 90° CCW
-                default -> image;                                 // 1 = normal, others are mirrored (rare)
+                case 3 -> rotateImage(image, Math.PI);           // 180
+                case 6 -> rotateImage(image, Math.PI / 2);       // 90 CW
+                case 8 -> rotateImage(image, -Math.PI / 2);      // 90 CCW
+                default -> image;                                 // 1 = normal
             };
         } catch (Exception e) {
             log.warn("Could not read EXIF orientation: {}", e.getMessage());
@@ -180,6 +315,8 @@ public class RecipeScanService {
     private String ocrBufferedImage(BufferedImage image) {
         try {
             BufferedImage processed = preprocessForOcr(image);
+            processed = detectAndFixRotation(processed);
+
             Tesseract tesseract = new Tesseract();
             tesseract.setLanguage("eng");
             String datapath = System.getenv("TESSDATA_PREFIX");
@@ -193,13 +330,52 @@ public class RecipeScanService {
         }
     }
 
+    private BufferedImage detectAndFixRotation(BufferedImage image) {
+        Path tempFile = null;
+        try {
+            tempFile = Files.createTempFile("osd-", ".png");
+            ImageIO.write(image, "png", tempFile.toFile());
+
+            ProcessBuilder pb = new ProcessBuilder(
+                    "tesseract", tempFile.toString(), "stdout", "--psm", "0");
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+            String output = new String(proc.getInputStream().readAllBytes());
+            proc.waitFor();
+
+            int rotation = parseOsdRotation(output);
+            if (rotation != 0) {
+                log.info("OSD detected Rotate:{} — applying correction", rotation);
+                double radians = Math.toRadians(rotation);
+                return rotateImage(image, radians);
+            }
+            return image;
+        } catch (Exception e) {
+            log.debug("OSD rotation detection failed (non-fatal): {}", e.getMessage());
+            return image;
+        } finally {
+            try { if (tempFile != null) Files.deleteIfExists(tempFile); } catch (Exception ignored) {}
+        }
+    }
+
+    private int parseOsdRotation(String osdOutput) {
+        for (String line : osdOutput.split("\n")) {
+            if (line.startsWith("Rotate:")) {
+                String value = line.substring("Rotate:".length()).trim();
+                try {
+                    return Integer.parseInt(value);
+                } catch (NumberFormatException e) {
+                    return 0;
+                }
+            }
+        }
+        return 0;
+    }
+
     private BufferedImage preprocessForOcr(BufferedImage image) {
         int w = image.getWidth();
         int h = image.getHeight();
 
-        // Downscale very large images. Tesseract expects ~300 DPI; a recipe card
-        // is roughly 8x10 inches, so ideal width is ~2400-3000 px.
-        // Phone photos can be 4000+ px wide — downscale to keep OCR accurate.
         int maxDim = 3000;
         if (w > maxDim || h > maxDim) {
             double scale = (double) maxDim / Math.max(w, h);
@@ -216,8 +392,6 @@ public class RecipeScanService {
             h = nh;
         }
 
-        // Convert to grayscale — LSTM works best on grayscale, not binary.
-        // Let Tesseract's internal Leptonica handle thresholding.
         BufferedImage gray = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_GRAY);
         gray.getGraphics().drawImage(image, 0, 0, null);
         return gray;
@@ -235,18 +409,14 @@ public class RecipeScanService {
             throw new RecipeImportException("No text could be extracted from the image");
         }
 
-        // Title = first non-empty line
         String title = nonEmpty.get(0);
 
-        // Extract servings
         int servings = 1;
         Matcher servMatcher = SERVINGS_PATTERN.matcher(text);
         if (servMatcher.find()) {
             servings = Integer.parseInt(servMatcher.group(1));
         }
 
-        // Split into ingredients section and instructions
-        // Ingredients are stored as (section, line) pairs to preserve sub-recipe grouping
         List<Map.Entry<String, String>> ingredientEntries = new ArrayList<>();
         List<String> instructionLines = new ArrayList<>();
         boolean inInstructions = false;
@@ -256,37 +426,30 @@ public class RecipeScanService {
             String line = nonEmpty.get(i);
             String lower = line.toLowerCase();
 
-            // Detect section headers
             if (lower.matches("^(instructions?|directions?|method|steps?|preparation)\\s*:?\\s*$")) {
                 inInstructions = true;
                 continue;
             }
             if (lower.matches("^(ingredients?)\\s*:?\\s*$")) {
                 inInstructions = false;
-                // Reset — anything before this header was metadata, not ingredients
                 ingredientEntries.clear();
                 currentSection = null;
                 continue;
             }
 
-            // Skip servings/time lines
             if (SERVINGS_PATTERN.matcher(line).find() || TIME_PATTERN.matcher(line).find()) {
                 continue;
             }
 
-            // Skip recipe metadata lines (Course, Cuisine, Keyword, Calories, etc.)
             if (METADATA_PATTERN.matcher(line).matches()) {
                 continue;
             }
 
-            // Detect sub-recipe section headers (only in ingredients)
             if (!inInstructions) {
-                // Lines with colon: "For the Marinade:", "Sauce:"
                 if (SUB_SECTION_WITH_COLON.matcher(line).matches()) {
                     currentSection = cleanSectionName(line);
                     continue;
                 }
-                // Short all-letter lines (≤4 words) without digits: "Soup", "Chicken Rub"
                 if (SUB_SECTION_SHORT_LABEL.matcher(line).matches()
                         && line.split("\\s+").length <= 4) {
                     currentSection = cleanSectionName(line);
@@ -295,7 +458,6 @@ public class RecipeScanService {
             }
 
             if (inInstructions) {
-                // Filter OCR garbage: short non-numeric, non-header lines
                 boolean isShortGarbage = line.length() <= 5
                         && !Character.isDigit(line.charAt(0))
                         && !line.toLowerCase().matches("notes?|tips?");
@@ -308,7 +470,6 @@ public class RecipeScanService {
             }
         }
 
-        // If we never found an "Instructions" header, assume second half is instructions
         if (instructionLines.isEmpty() && ingredientEntries.size() > 3) {
             int split = ingredientEntries.size() / 2;
             for (int i = split; i < ingredientEntries.size(); i++) {
@@ -317,9 +478,6 @@ public class RecipeScanService {
             ingredientEntries = new ArrayList<>(ingredientEntries.subList(0, split));
         }
 
-        // Parse ingredients — strip leading OCR artifacts (bullets, slashes, dashes, etc.).
-        // Trim whitespace, then strip any leading non-alphanumeric junk until we hit a
-        // letter or digit (the start of a quantity or ingredient name).
         List<ImportedIngredientPreview> ingredients = ingredientEntries.stream()
                 .filter(entry -> {
                     String cleaned = entry.getValue().trim().replaceFirst("^[^\\p{L}\\p{N}]+", "").trim();
@@ -329,21 +487,10 @@ public class RecipeScanService {
                     String section = entry.getKey();
                     String line = entry.getValue().trim().replaceFirst("^[^\\p{L}\\p{N}]+", "").trim();
                     ImportedIngredientPreview parsed = recipeImportService.parseIngredientText(line);
-                    return new ImportedIngredientPreview(section, parsed.name(), parsed.quantity(), parsed.unit(), parsed.rawText());
+                    return new ImportedIngredientPreview(section, parsed.name(), parsed.quantity(), parsed.unit(), parsed.rawText(), null);
                 })
                 .toList();
 
-        // Build instructions — merge continuation lines from multi-line OCR steps.
-        //
-        // Two modes depending on how the OCR captured the numbering:
-        //   "inline"   — number + text on same line:  "1. Heat a pan on medium."
-        //   "orphaned" — number alone on its own line: "1."  then "Heat a pan..."
-        //
-        // Inline mode: uppercase after "N." = new step; lowercase = continuation.
-        // Orphaned mode: skip bare number lines; each uppercase-starting line = new step;
-        //   lowercase-starting lines = continuation of previous step.
-        //
-        // Notes/Tips sections and bullet lines are handled in both modes.
         List<String> mergedInstructions = new ArrayList<>();
         List<String> notes = new ArrayList<>();
         java.util.regex.Pattern inlineStepPattern = java.util.regex.Pattern.compile("^\\d+\\.\\s+([A-Z].+)");
@@ -352,9 +499,8 @@ public class RecipeScanService {
         java.util.regex.Pattern notesHeaderPattern = java.util.regex.Pattern.compile(
                 "^(?:\\d+\\.\\s*)?(?i)(notes?|tips?|variations?)\\s*$");
         java.util.regex.Pattern bulletPattern = java.util.regex.Pattern.compile(
-                "^(?:\\d+\\.\\s*)?[+*\\-•]\\s*(.+)");
+                "^(?:\\d+\\.\\s*)?[+*\\-\u2022]\\s*(.+)");
 
-        // Determine mode: count inline vs orphaned numbered lines
         long inlineCount = instructionLines.stream()
                 .filter(l -> inlineStepPattern.matcher(l).matches())
                 .count();
@@ -365,13 +511,11 @@ public class RecipeScanService {
         boolean inNotes = false;
 
         for (String line : instructionLines) {
-            // Notes/tips section header
             if (notesHeaderPattern.matcher(line).matches()) {
                 inNotes = true;
                 continue;
             }
 
-            // Bullet lines (+ / * / -)
             java.util.regex.Matcher bulletMatcher = bulletPattern.matcher(line);
             if (bulletMatcher.matches()) {
                 if (inNotes) {
@@ -383,7 +527,6 @@ public class RecipeScanService {
             }
 
             if (inNotes) {
-                // Non-bullet continuation in notes section
                 if (!notes.isEmpty()) {
                     int last = notes.size() - 1;
                     java.util.regex.Matcher numMatcher = numPrefixPattern.matcher(line);
@@ -395,14 +538,11 @@ public class RecipeScanService {
                 continue;
             }
 
-            // Skip bare number lines ("10.", "11.") in both modes
             if (bareNumberPattern.matcher(line).matches()) {
                 continue;
             }
 
             if (useOrphanedMode) {
-                // Orphaned mode: each uppercase-starting sentence is a new step
-                // Strip any leading ". " from OCR artifacts (". Once roasted...")
                 String cleaned = line.replaceFirst("^\\d*\\.\\s*", "").trim();
                 if (cleaned.isEmpty()) continue;
 
@@ -415,7 +555,6 @@ public class RecipeScanService {
                     mergedInstructions.add(cleaned);
                 }
             } else {
-                // Inline mode: "N. Uppercase" = new step, lowercase = continuation
                 java.util.regex.Matcher stepMatcher = inlineStepPattern.matcher(line);
                 if (stepMatcher.matches()) {
                     mergedInstructions.add(stepMatcher.group(1));
@@ -452,4 +591,21 @@ public class RecipeScanService {
                 .trim();
     }
 
+
+    /**
+     * Lightweight MultipartFile wrapper for converted image bytes.
+     */
+    private record SimpleMultipartFile(String name, String contentType, byte[] bytes)
+            implements MultipartFile {
+        @Override public String getName() { return "file"; }
+        @Override public String getOriginalFilename() { return name; }
+        @Override public String getContentType() { return contentType; }
+        @Override public boolean isEmpty() { return bytes.length == 0; }
+        @Override public long getSize() { return bytes.length; }
+        @Override public byte[] getBytes() { return bytes; }
+        @Override public InputStream getInputStream() { return new java.io.ByteArrayInputStream(bytes); }
+        @Override public void transferTo(java.io.File dest) throws IOException {
+            Files.write(dest.toPath(), bytes);
+        }
+    }
 }

--- a/src/main/java/com/endoran/foodplan/service/RecipeService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeService.java
@@ -1,6 +1,8 @@
 package com.endoran.foodplan.service;
 
 import com.endoran.foodplan.dto.CreateRecipeRequest;
+import com.endoran.foodplan.dto.ImportedIngredientPreview;
+import com.endoran.foodplan.dto.ImportedRecipePreview;
 import com.endoran.foodplan.dto.RecipeIngredientResponse;
 import com.endoran.foodplan.dto.RecipeResponse;
 import com.endoran.foodplan.dto.UpdateRecipeRequest;
@@ -8,8 +10,14 @@ import com.endoran.foodplan.model.Ingredient;
 import com.endoran.foodplan.model.Measurement;
 import com.endoran.foodplan.model.Recipe;
 import com.endoran.foodplan.model.RecipeIngredient;
+import com.endoran.foodplan.model.ScanSession;
+import com.endoran.foodplan.model.TrainingPair;
 import com.endoran.foodplan.repository.IngredientRepository;
 import com.endoran.foodplan.repository.RecipeRepository;
+import com.endoran.foodplan.repository.ScanSessionRepository;
+import com.endoran.foodplan.repository.TrainingPairRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -19,17 +27,26 @@ import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 public class RecipeService {
 
+    private static final Logger log = LoggerFactory.getLogger(RecipeService.class);
+
     private final RecipeRepository recipeRepository;
     private final IngredientRepository ingredientRepository;
+    private final ScanSessionRepository scanSessionRepository;
+    private final TrainingPairRepository trainingPairRepository;
     private GlobalRecipeService globalRecipeService;
 
-    public RecipeService(RecipeRepository recipeRepository, IngredientRepository ingredientRepository) {
+    public RecipeService(RecipeRepository recipeRepository, IngredientRepository ingredientRepository,
+                         ScanSessionRepository scanSessionRepository, TrainingPairRepository trainingPairRepository) {
         this.recipeRepository = recipeRepository;
         this.ingredientRepository = ingredientRepository;
+        this.scanSessionRepository = scanSessionRepository;
+        this.trainingPairRepository = trainingPairRepository;
     }
 
     @Autowired(required = false)
@@ -47,7 +64,93 @@ public class RecipeService {
         recipe.setIngredients(toIngredients(request.ingredients()));
         autoCreateIngredients(orgId, recipe.getIngredients());
         recipe = recipeRepository.save(recipe);
+
+        // Generate training pair if this recipe came from a scan
+        if (request.scanSessionId() != null) {
+            generateTrainingPair(orgId, request);
+        }
+
         return toResponse(recipe, null, orgId);
+    }
+
+    private void generateTrainingPair(String orgId, CreateRecipeRequest request) {
+        try {
+            var sessionOpt = scanSessionRepository.findById(request.scanSessionId());
+            if (sessionOpt.isEmpty()) {
+                log.warn("Scan session {} not found (expired?), skipping training pair", request.scanSessionId());
+                return;
+            }
+            ScanSession session = sessionOpt.get();
+
+            int index = request.scanRecipeIndex() != null ? request.scanRecipeIndex() : 0;
+            if (index < 0 || index >= session.getModelOutput().size()) {
+                log.warn("Scan recipe index {} out of range for session {} (has {} recipes)",
+                        index, session.getId(), session.getModelOutput().size());
+                return;
+            }
+
+            ImportedRecipePreview modelOutput = session.getModelOutput().get(index);
+
+            // Build corrected output from what the user actually saved
+            List<ImportedIngredientPreview> correctedIngredients = request.ingredients().stream()
+                    .map(ri -> new ImportedIngredientPreview(
+                            ri.section(), ri.ingredientName(),
+                            ri.quantity(), ri.unit().name(), null, null))
+                    .collect(Collectors.toList());
+            ImportedRecipePreview correctedOutput = new ImportedRecipePreview(
+                    request.name(), request.instructions(), request.baseServings(),
+                    correctedIngredients, modelOutput.sourceUrl());
+
+            boolean hasCorrections = !recipePreviewsMatch(modelOutput, correctedOutput);
+
+            TrainingPair pair = new TrainingPair();
+            pair.setOrgId(orgId);
+            pair.setScanSessionId(session.getId());
+            pair.setImageData(session.getImageData());
+            pair.setImageContentType(session.getImageContentType());
+            pair.setModelOutput(modelOutput);
+            pair.setCorrectedOutput(correctedOutput);
+            pair.setExtractionTier(session.getExtractionTier());
+            pair.setHasCorrections(hasCorrections);
+            trainingPairRepository.save(pair);
+
+            log.info("Training pair saved (session={}, corrections={}, tier={})",
+                    session.getId(), hasCorrections, session.getExtractionTier());
+
+            // Delete scan session if all recipes have been consumed
+            // For simplicity, delete after first save — multi-recipe sessions
+            // will create one pair per save call
+            scanSessionRepository.deleteById(session.getId());
+
+        } catch (Exception e) {
+            // Training pair generation should never fail the recipe save
+            log.error("Failed to generate training pair for session {}: {}",
+                    request.scanSessionId(), e.getMessage());
+        }
+    }
+
+    private boolean recipePreviewsMatch(ImportedRecipePreview original, ImportedRecipePreview corrected) {
+        if (!Objects.equals(original.name(), corrected.name())) return false;
+        if (original.baseServings() != corrected.baseServings()) return false;
+        if (!Objects.equals(original.instructions(), corrected.instructions())) return false;
+
+        List<ImportedIngredientPreview> origIngs = original.ingredients();
+        List<ImportedIngredientPreview> corrIngs = corrected.ingredients();
+        if (origIngs.size() != corrIngs.size()) return false;
+
+        for (int i = 0; i < origIngs.size(); i++) {
+            ImportedIngredientPreview o = origIngs.get(i);
+            ImportedIngredientPreview c = corrIngs.get(i);
+            if (!Objects.equals(o.name(), c.name())) return false;
+            if (!Objects.equals(o.section(), c.section())) return false;
+            if (!Objects.equals(o.unit(), c.unit())) return false;
+            if (o.quantity() != null && c.quantity() != null) {
+                if (o.quantity().compareTo(c.quantity()) != 0) return false;
+            } else if (o.quantity() != c.quantity()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public RecipeResponse getById(String orgId, String id, Integer targetServings) {
@@ -179,7 +282,6 @@ public class RecipeService {
 
     private void autoCreateIngredients(String orgId, List<RecipeIngredient> ingredients) {
         for (RecipeIngredient ri : ingredients) {
-            // Skip if already resolved
             if (ri.getIngredientId() != null && !ri.getIngredientId().isBlank()) continue;
 
             var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(

--- a/src/main/java/com/endoran/foodplan/service/UnitConverter.java
+++ b/src/main/java/com/endoran/foodplan/service/UnitConverter.java
@@ -26,9 +26,15 @@ public final class UnitConverter {
         TO_BASE.put(MeasurementUnit.QUART, new BigDecimal("192"));
         TO_BASE.put(MeasurementUnit.HALF_GALLON, new BigDecimal("384"));
         TO_BASE.put(MeasurementUnit.GALLON, new BigDecimal("768"));
+        // Metric volume → TSP (1 tsp ≈ 4.929 ml)
+        TO_BASE.put(MeasurementUnit.ML, new BigDecimal("0.2029"));
+        TO_BASE.put(MeasurementUnit.L, new BigDecimal("202.884"));
         // Weight → OZ
         TO_BASE.put(MeasurementUnit.OZ, BigDecimal.ONE);
         TO_BASE.put(MeasurementUnit.LBS, new BigDecimal("16"));
+        // Metric weight → OZ (1 oz ≈ 28.3495 g)
+        TO_BASE.put(MeasurementUnit.G, new BigDecimal("0.03527"));
+        TO_BASE.put(MeasurementUnit.KG, new BigDecimal("35.274"));
     }
 
     private static final Map<MeasurementUnit, UnitFamily> FAMILIES = new EnumMap<>(MeasurementUnit.class);
@@ -42,8 +48,12 @@ public final class UnitConverter {
         FAMILIES.put(MeasurementUnit.QUART, UnitFamily.VOLUME);
         FAMILIES.put(MeasurementUnit.HALF_GALLON, UnitFamily.VOLUME);
         FAMILIES.put(MeasurementUnit.GALLON, UnitFamily.VOLUME);
+        FAMILIES.put(MeasurementUnit.ML, UnitFamily.VOLUME);
+        FAMILIES.put(MeasurementUnit.L, UnitFamily.VOLUME);
         FAMILIES.put(MeasurementUnit.OZ, UnitFamily.WEIGHT);
         FAMILIES.put(MeasurementUnit.LBS, UnitFamily.WEIGHT);
+        FAMILIES.put(MeasurementUnit.G, UnitFamily.WEIGHT);
+        FAMILIES.put(MeasurementUnit.KG, UnitFamily.WEIGHT);
     }
 
     // Ordered largest → smallest for readable output (grocery-friendly units only)


### PR DESCRIPTION
## Summary

- **Active Learning Feedback Loop**: Captures original model output alongside user corrections as training pairs for future LoRA fine-tuning of the vision model
- **Handwritten Recipe Support**: OSD-based rotation detection, image downscaling, updated vision prompt to handle handwritten recipe cards
- **Quality of Life**: Increased Ollama timeout, .gitignore cleanup

## Active Learning Details

When a user scans a recipe photo, the raw model output is persisted in a ScanSession (24h TTL auto-cleanup). When they save the recipe (potentially corrected), the backend diffs original vs corrected output and stores a TrainingPair. Training pair generation is fire-and-forget and never fails recipe save.

New MongoDB collections: scan_sessions, training_pairs

## Handwritten Scan Improvements

Tested against 18 recipe images (mix of printed and handwritten):
- Before: 3/18 extracted correctly (printed only), all handwritten = complete failure
- After: 5/18 extracted correctly. Lasagna (handwritten) now works via OSD rotation + OCR + text LLM path

Changes:
- Vision prompt no longer ignores handwritten text
- Tesseract OSD detects text orientation and auto-corrects rotation before OCR
- Images downscaled to 1568px max for optimal vision model processing
- Landscape images auto-rotated to portrait
- Ollama timeout increased 120s to 180s

## Known Limitations

Remaining handwritten failures are model capability limitations. Qwen2.5-VL 7B struggles with cursive/artistic handwriting. Future improvement: accumulate training pairs and LoRA fine-tune.

## Test Plan

- [x] Scan printed recipe (Orange Chicken) extracts correctly
- [x] Scan handwritten+rotated recipe (Lasagna) now extracts correctly (was failing)
- [x] Scan printed+rotated recipe (Beef and Broccoli) extracts correctly
- [x] Non-scan recipe creation still works (scanSessionId is null)
- [x] Both targets build successfully
- [ ] Verify training pair creation end-to-end in UI
