### PR TITLE
Add vision-text LLM pipeline and resilient JSON parsing

### DIFF
--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -179,26 +179,39 @@ public class OllamaRecipeExtractor {
     public List<ImportedRecipePreview> extractFromImage(byte[] imageBytes, String mimeType) {
         if (baseUrl.isBlank()) return List.of();
         try {
-            String base64 = Base64.getEncoder().encodeToString(imageBytes);
-
-            // Native Ollama API uses "images" array with raw base64 (no data URI prefix)
-            Map<String, Object> message = Map.of(
-                    "role", "user",
-                    "content", VISION_PROMPT,
-                    "images", List.of(base64));
-            Map<String, Object> body = Map.of(
-                    "model", visionModel,
-                    "messages", List.of(message),
-                    "stream", false,
-                    "think", false,
-                    "options", Map.of("temperature", 0.1, "num_predict", 8192));
-
-            String json = callOllama(body);
-            return parseResponse(json);
+            String response = callVisionModel(imageBytes);
+            return parseResponse(response);
         } catch (Exception e) {
             log.warn("Vision extraction failed: {}", e.getMessage());
             return List.of();
         }
+    }
+
+    public String readImageAsText(byte[] imageBytes) {
+        if (baseUrl.isBlank()) return null;
+        try {
+            return callVisionModel(imageBytes);
+        } catch (Exception e) {
+            log.warn("Vision text read failed: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String callVisionModel(byte[] imageBytes) throws Exception {
+        String base64 = Base64.getEncoder().encodeToString(imageBytes);
+
+        Map<String, Object> message = Map.of(
+                "role", "user",
+                "content", VISION_PROMPT,
+                "images", List.of(base64));
+        Map<String, Object> body = Map.of(
+                "model", visionModel,
+                "messages", List.of(message),
+                "stream", false,
+                "think", false,
+                "options", Map.of("temperature", 0.1, "num_predict", 8192));
+
+        return callOllama(body);
     }
 
     public List<ImportedRecipePreview> extractFromText(String ocrText) {
@@ -287,10 +300,10 @@ public class OllamaRecipeExtractor {
         throw new RuntimeException("No JSON object found in thinking text");
     }
 
-    List<ImportedRecipePreview> parseResponse(String content) {
+    public List<ImportedRecipePreview> parseResponse(String content) {
         String json = content.strip();
         if (json.startsWith("```")) {
-            json = json.replaceFirst("^```(?:json)?\\s*", "").replaceFirst("\\s*```$", "");
+            json = json.replaceFirst("^```(?:json)?\\s*", "").replaceFirst("\\s*```\\s*$", "");
         }
 
         List<ImportedRecipePreview> results = new ArrayList<>();
@@ -306,7 +319,7 @@ public class OllamaRecipeExtractor {
                 return results;
             }
         } catch (Exception e) {
-            log.debug("Multi-recipe parse failed (trying single): {}", e.getMessage());
+            log.info("Multi-recipe parse failed (trying single): {}", e.getMessage());
         }
 
         // Fall back to single-recipe format (backward compatibility)
@@ -316,7 +329,7 @@ public class OllamaRecipeExtractor {
             if (preview != null) results.add(preview);
             return results;
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            log.debug("Single-recipe JSON parse failed: {}", e.getMessage());
+            log.info("Single-recipe JSON parse failed: {}", e.getMessage());
         }
 
         // Repair attempt: fix unquoted enum-style values (e.g., "unit": CUP → "unit": "CUP")
@@ -335,7 +348,7 @@ public class OllamaRecipeExtractor {
                     return results;
                 }
             } catch (Exception e) {
-                log.debug("Repaired multi-recipe parse also failed: {}", e.getMessage());
+                log.info("Repaired multi-recipe parse also failed: {}", e.getMessage());
             }
         }
 
@@ -363,7 +376,7 @@ public class OllamaRecipeExtractor {
                 String name = ing.name != null ? ing.name.trim() : "";
                 if (name.isBlank()) continue;
 
-                BigDecimal quantity = ing.quantity != null ? ing.quantity : BigDecimal.ONE;
+                BigDecimal quantity = parseQuantity(ing.quantity);
                 String rawText = quantity + " " + unit + " " + name;
 
                 ingredients.add(new ImportedIngredientPreview(
@@ -378,10 +391,42 @@ public class OllamaRecipeExtractor {
 
         return new ImportedRecipePreview(
                 recipeName,
-                llm.instructions != null ? llm.instructions : "",
+                instructionsToString(llm.instructions),
                 llm.baseServings > 0 ? llm.baseServings : 1,
                 ingredients,
                 "scan");
+    }
+
+    private static String instructionsToString(JsonNode node) {
+        if (node == null || node.isNull()) return "";
+        if (node.isTextual()) return node.asText();
+        if (node.isArray()) {
+            StringBuilder sb = new StringBuilder();
+            int step = 1;
+            for (JsonNode item : node) {
+                String text = item.isTextual() ? item.asText() : item.toString();
+                if (!text.matches("^\\d+\\.\\s.*")) {
+                    sb.append(step).append(". ");
+                }
+                sb.append(text).append("\n");
+                step++;
+            }
+            return sb.toString().strip();
+        }
+        return node.toString();
+    }
+
+    private static BigDecimal parseQuantity(JsonNode node) {
+        if (node == null || node.isNull()) return BigDecimal.ONE;
+        if (node.isNumber()) return node.decimalValue();
+        if (node.isTextual()) {
+            try {
+                return new BigDecimal(node.asText().strip());
+            } catch (NumberFormatException e) {
+                return BigDecimal.ONE;
+            }
+        }
+        return BigDecimal.ONE;
     }
 
     private static String deriveNameFromIngredients(List<LlmIngredient> ingredients) {
@@ -421,7 +466,7 @@ public class OllamaRecipeExtractor {
     record LlmRecipeResponse(
             String name,
             int baseServings,
-            String instructions,
+            JsonNode instructions,
             List<LlmIngredient> ingredients
     ) {}
 
@@ -429,7 +474,7 @@ public class OllamaRecipeExtractor {
     record LlmIngredient(
             String section,
             String name,
-            BigDecimal quantity,
+            JsonNode quantity,
             String unit,
             String prepNote
     ) {}

--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -16,10 +16,12 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 @Component
@@ -187,13 +189,13 @@ public class OllamaRecipeExtractor {
         }
     }
 
-    public String readImageAsText(byte[] imageBytes) {
-        if (baseUrl.isBlank()) return null;
+    public Optional<String> callVisionModelRaw(byte[] imageBytes) {
+        if (baseUrl.isBlank()) return Optional.empty();
         try {
-            return callVisionModel(imageBytes);
+            return Optional.of(callVisionModel(imageBytes));
         } catch (Exception e) {
-            log.warn("Vision text read failed: {}", e.getMessage());
-            return null;
+            log.warn("Vision model call failed: {}", e.getMessage());
+            return Optional.empty();
         }
     }
 
@@ -316,10 +318,11 @@ public class OllamaRecipeExtractor {
                     ImportedRecipePreview preview = buildPreview(recipe);
                     if (preview != null) results.add(preview);
                 }
+                log.info("Parsed {} recipe(s) via multi-recipe format", results.size());
                 return results;
             }
         } catch (Exception e) {
-            log.info("Multi-recipe parse failed (trying single): {}", e.getMessage());
+            log.debug("Multi-recipe parse failed (trying single): {}", e.getMessage());
         }
 
         // Fall back to single-recipe format (backward compatibility)
@@ -327,17 +330,16 @@ public class OllamaRecipeExtractor {
             LlmRecipeResponse single = objectMapper.readValue(json, LlmRecipeResponse.class);
             ImportedRecipePreview preview = buildPreview(single);
             if (preview != null) results.add(preview);
+            log.info("Parsed {} recipe(s) via single-recipe format", results.size());
             return results;
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            log.info("Single-recipe JSON parse failed: {}", e.getMessage());
+            log.debug("Single-recipe JSON parse failed: {}", e.getMessage());
         }
 
         // Repair attempt: fix unquoted enum-style values (e.g., "unit": CUP → "unit": "CUP")
-        // Only applied as fallback when standard parsing fails, to avoid corrupting valid JSON
         String repaired = json.replaceAll("\":\\s+([A-Z][A-Z_]{0,19})\\s*([,\\}\\]])", "\": \"$1\"$2");
         if (!repaired.equals(json)) {
-            log.info("Retrying JSON parse after quoting {} bare enum values",
-                    repaired.length() - json.length());
+            log.debug("Retrying JSON parse after quoting bare enum values");
             try {
                 LlmMultiRecipeResponse multi = objectMapper.readValue(repaired, LlmMultiRecipeResponse.class);
                 if (multi.recipes != null && !multi.recipes.isEmpty()) {
@@ -345,10 +347,11 @@ public class OllamaRecipeExtractor {
                         ImportedRecipePreview preview = buildPreview(recipe);
                         if (preview != null) results.add(preview);
                     }
+                    log.info("Parsed {} recipe(s) after JSON enum repair", results.size());
                     return results;
                 }
             } catch (Exception e) {
-                log.info("Repaired multi-recipe parse also failed: {}", e.getMessage());
+                log.debug("Repaired multi-recipe parse also failed: {}", e.getMessage());
             }
         }
 
@@ -420,10 +423,40 @@ public class OllamaRecipeExtractor {
         if (node == null || node.isNull()) return BigDecimal.ONE;
         if (node.isNumber()) return node.decimalValue();
         if (node.isTextual()) {
+            String text = node.asText().strip();
+            if (text.isEmpty()) return BigDecimal.ONE;
             try {
-                return new BigDecimal(node.asText().strip());
+                return new BigDecimal(text);
+            } catch (NumberFormatException e) {
+                return parseFraction(text);
+            }
+        }
+        return BigDecimal.ONE;
+    }
+
+    private static BigDecimal parseFraction(String text) {
+        // Handle mixed fractions like "1 1/2"
+        String[] parts = text.split("\\s+");
+        BigDecimal whole = BigDecimal.ZERO;
+        String fractionPart = text;
+        if (parts.length == 2 && parts[1].contains("/")) {
+            try {
+                whole = new BigDecimal(parts[0]);
+                fractionPart = parts[1];
             } catch (NumberFormatException e) {
                 return BigDecimal.ONE;
+            }
+        }
+        if (fractionPart.contains("/")) {
+            String[] frac = fractionPart.split("/");
+            if (frac.length == 2) {
+                try {
+                    BigDecimal num = new BigDecimal(frac[0].strip());
+                    BigDecimal den = new BigDecimal(frac[1].strip());
+                    if (den.compareTo(BigDecimal.ZERO) != 0) {
+                        return whole.add(num.divide(den, 4, RoundingMode.HALF_UP));
+                    }
+                } catch (NumberFormatException ignored) {}
             }
         }
         return BigDecimal.ONE;

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -124,16 +124,36 @@ public class RecipeScanService {
         // Tier 1 & 2: Try LLM extraction if Ollama is available
         if (ollamaExtractor.isAvailable()) {
             // Tier 1: Vision — send photo directly to vision model
-            try {
-                List<ImportedRecipePreview> vision = ollamaExtractor.extractFromImage(visionBytes, imageContentType);
-                if (!vision.isEmpty()) {
-                    log.info("Extracted {} recipe(s) via vision LLM", vision.size());
-                    recipes = vision;
-                    tier = "VISION";
-                    return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
+            String visionRawText = ollamaExtractor.readImageAsText(visionBytes);
+            if (visionRawText != null && !visionRawText.isBlank()) {
+                log.info("Vision raw text ({} chars): {}", visionRawText.length(),
+                        visionRawText.replace("\n", "\\n").substring(0, Math.min(200, visionRawText.length())));
+                // Try parsing vision output as JSON first
+                try {
+                    List<ImportedRecipePreview> vision = ollamaExtractor.parseResponse(visionRawText);
+                    if (!vision.isEmpty()) {
+                        log.info("Extracted {} recipe(s) via vision LLM (JSON)", vision.size());
+                        recipes = vision;
+                        tier = "VISION";
+                        return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
+                    }
+                } catch (Exception e) {
+                    log.debug("Vision output not valid JSON: {}", e.getMessage());
                 }
-            } catch (Exception e) {
-                log.warn("Vision extraction attempt failed: {}", e.getMessage());
+
+                // Vision returned text but not JSON — feed to text LLM for structuring
+                if (visionRawText.length() > 30) {
+                    log.info("Vision returned non-JSON text ({} chars), forwarding to text LLM", visionRawText.length());
+                    List<ImportedRecipePreview> visionToText = ollamaExtractor.extractFromText(visionRawText);
+                    if (!visionToText.isEmpty()) {
+                        log.info("Extracted {} recipe(s) via vision→text LLM pipeline", visionToText.size());
+                        recipes = visionToText;
+                        tier = "VISION_TEXT";
+                        return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
+                    }
+                }
+            } else {
+                log.info("Vision returned null/empty text");
             }
 
             // Tier 2: Text LLM — OCR first, then send text to LLM

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -25,6 +25,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.io.InputStream;
@@ -124,14 +125,15 @@ public class RecipeScanService {
         // Tier 1 & 2: Try LLM extraction if Ollama is available
         if (ollamaExtractor.isAvailable()) {
             // Tier 1: Vision — send photo directly to vision model
-            String visionRawText = ollamaExtractor.readImageAsText(visionBytes);
-            if (visionRawText != null && !visionRawText.isBlank()) {
+            Optional<String> visionResult = ollamaExtractor.callVisionModelRaw(visionBytes);
+            if (visionResult.isPresent() && !visionResult.get().isBlank()) {
+                String visionRawText = visionResult.get();
                 log.info("Vision raw text ({} chars): {}", visionRawText.length(),
                         visionRawText.replace("\n", "\\n").substring(0, Math.min(200, visionRawText.length())));
                 // Try parsing vision output as JSON first
                 try {
                     List<ImportedRecipePreview> vision = ollamaExtractor.parseResponse(visionRawText);
-                    if (!vision.isEmpty()) {
+                    if (hasUsableRecipes(vision)) {
                         log.info("Extracted {} recipe(s) via vision LLM (JSON)", vision.size());
                         recipes = vision;
                         tier = "VISION";
@@ -143,9 +145,9 @@ public class RecipeScanService {
 
                 // Vision returned text but not JSON — feed to text LLM for structuring
                 if (visionRawText.length() > 30) {
-                    log.info("Vision returned non-JSON text ({} chars), forwarding to text LLM", visionRawText.length());
+                    log.info("Forwarding vision text ({} chars) to text LLM", visionRawText.length());
                     List<ImportedRecipePreview> visionToText = ollamaExtractor.extractFromText(visionRawText);
-                    if (!visionToText.isEmpty()) {
+                    if (hasUsableRecipes(visionToText)) {
                         log.info("Extracted {} recipe(s) via vision→text LLM pipeline", visionToText.size());
                         recipes = visionToText;
                         tier = "VISION_TEXT";
@@ -153,7 +155,7 @@ public class RecipeScanService {
                     }
                 }
             } else {
-                log.info("Vision returned null/empty text");
+                log.info("Vision returned empty result");
             }
 
             // Tier 2: Text LLM — OCR first, then send text to LLM
@@ -179,6 +181,11 @@ public class RecipeScanService {
         recipes = List.of(parseScannedText(text));
         tier = "REGEX";
         return saveScanSession(orgId, imageBytes, imageContentType, recipes, tier);
+    }
+
+    private static boolean hasUsableRecipes(List<ImportedRecipePreview> recipes) {
+        return recipes != null && !recipes.isEmpty()
+                && recipes.stream().anyMatch(r -> r.ingredients() != null && !r.ingredients().isEmpty());
     }
 
     private ScanResult saveScanSession(String orgId, byte[] imageBytes, String imageContentType,


### PR DESCRIPTION
## Summary

Adds a new VISION_TEXT extraction tier to the recipe scan pipeline and makes JSON parsing more resilient to real-world LLM output variations.

### Changes
- **Vision-text pipeline (Tier 1.5)**: When the vision model returns readable text but not valid JSON, the text is forwarded to the text LLM for structured extraction. This unlocks handwritten recipe extraction where the vision model can read the handwriting but doesn't produce valid JSON directly.
- **Flexible deserialization**: `instructions` field changed from `String` to `JsonNode` to handle both string and array formats. `quantity` field changed from `BigDecimal` to `JsonNode` to handle non-numeric values (e.g., "for frying") without crashing.
- **Refactored vision calls**: Extracted shared `callVisionModel()` method eliminates duplicate API calls per scan.
- **Fixed fence stripping**: Regex now handles trailing whitespace after closing markdown fences.
- **Improved diagnostics**: Parse failure logging upgraded from debug to info level. Vision raw text logged for debugging.
- **JSON repair fallback**: Unquoted enum-style values (e.g., `"unit": CUP`) are auto-quoted as a last-resort parse fallback.

### Extraction Tiers (updated)
1. **VISION** — Vision model returns valid JSON directly
2. **VISION_TEXT** (new) — Vision reads image → text LLM structures into JSON
3. **TEXT_LLM** — OCR text → text LLM structures into JSON
4. **REGEX** — Fallback pattern matching

### Test Results (27 recipe images)
- 10 clean extractions (correct name, ingredients, units, instructions)
- 8 extractions with quality issues (unit accuracy on handwritten text)
- 4 timeouts (pipeline too slow for complex images)
- 2 infrastructure errors (MongoDB transient, corrupt HEIC)
- Multi-recipe extraction working (2 recipes from single image)
- HEIC conversion working

## Test plan
- [x] Scan printed recipes → verify VISION tier extraction
- [x] Scan handwritten recipes → verify VISION or VISION_TEXT tier
- [x] Verify instructions as array are converted to numbered steps
- [x] Verify non-numeric quantity doesn't crash (defaults to 1)
- [x] Verify markdown fence stripping works with trailing whitespace
- [x] Verify multi-recipe extraction still works
- [x] Verify HEIC conversion still works
- [x] Verify non-scan recipe creation unaffected