### PR TITLE
Strengthen scan prompts and add WHOLE-unit quality gate

### DIFF
--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -106,6 +106,9 @@ public class OllamaRecipeExtractor {
             Map.entry("CUPS", "CUP"), Map.entry("PINTS", "PINT"),
             Map.entry("QUARTS", "QUART"), Map.entry("GALLONS", "GALLON"));
 
+    // Unit abbreviation rules are intentionally duplicated between VISION_PROMPT and RULES:
+    // vision models need critical rules reinforced in the immediate prompt context, not just in
+    // a distant shared rules section, to reliably apply them.
     private static final String VISION_PROMPT = """
             You are a recipe extraction assistant. Analyze this photo of a recipe card or page and extract ALL recipes as JSON.
 

--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -61,6 +61,12 @@ public class OllamaRecipeExtractor {
             Ingredient names are NEVER sections. A section groups multiple ingredients under a sub-recipe label. If no clear section headers exist, set section to null.
             - Valid units (MUST be quoted strings in JSON): "TSP", "TBSP", "CUP", "PINT", "QUART", "GALLON", "HALF_GALLON", "FL_OZ", "WHOLE", "LBS", "OZ", "PINCH", "PIECE", "G", "ML", "KG", "L"
             - Common abbreviations: c./C. = CUP, lb./lbs. = LBS, tsp./t. = TSP, tbsp./T. = TBSP, oz. = OZ, pkg. = PIECE, env. = PIECE, pt. = PINT, qt. = QUART
+            - CRITICAL unit abbreviation rules for HANDWRITTEN recipes: \
+            A lowercase "t" or "t." before or after a number ALWAYS means TSP. \
+            An uppercase "T" or "T." before or after a number ALWAYS means TBSP. \
+            A lowercase "c" or "c." ALWAYS means CUP. \
+            Examples: "1 t salt" = 1 TSP salt, "2 T butter" = 2 TBSP butter, "1c milk" = 1 CUP milk, "1/2 c flour" = 0.5 CUP flour. \
+            NEVER map these to WHOLE — they are always measurement abbreviations.
             - Use WHOLE for items counted by number (e.g., "3 eggs" -> quantity 3, unit WHOLE)
             - Use PINCH for "doonks", dashes, or pinches
             - NAME = shopping-list item. Strip ALL prep verbs (peeled, chopped, minced, sliced, diced, grated, beaten, etc.)
@@ -110,8 +116,17 @@ public class OllamaRecipeExtractor {
             - RECIPE TITLE: Look for the most prominent text (larger, bold, decorative font). \
             Ignore small diet/lifestyle tags like "NSI", "DF", "S", "E", "FP", "FRIENDLY", "KETO", "PALEO" — these are NOT the recipe name.
             - If ingredients are in two columns, read the LEFT column top-to-bottom first, then the RIGHT column
-            - Look for sub-recipe section headers like "For the Dough:", "Filling:", "Sauce:" — group ingredients under these sections
-            - For handwritten text, common abbreviations: c=cup, t/tsp=teaspoon, T/tbsp=tablespoon, lb=pound, oz=ounce, pkg=package
+            - Look for sub-recipe section headers like "For the Dough:", "Filling:", "Sauce:" — group ingredients under these sections. \
+            IMPORTANT: Individual ingredient names (butter, milk, eggs, garlic, etc.) are NEVER section names. \
+            A section is a sub-recipe label that groups multiple ingredients (e.g., "Marinade", "Sauce", "Dough"). \
+            If there are no clear multi-ingredient section headers, set section to null for ALL ingredients.
+            - For handwritten text, UNIT ABBREVIATION is CRITICAL: \
+            lowercase "t" or "t." = TSP (teaspoon), uppercase "T" or "T." = TBSP (tablespoon), \
+            "c" or "c." = CUP, "lb" = LBS, "oz" = OZ, "pkg" = PIECE. \
+            Example: "1 t salt" = {"quantity": 1, "unit": "TSP"}, "2 T butter" = {"quantity": 2, "unit": "TBSP"}, "1c milk" = {"quantity": 1, "unit": "CUP"}. \
+            NEVER use WHOLE when a measurement abbreviation is present.
+            - If a recipe card has multiple columns for different serving sizes (single/double/triple/quad), \
+            extract ONLY the first (smallest) column values
             - "Makes X" or "Serves X" indicates baseServings
             """ + RECIPE_SCHEMA + "\n\n" + RULES;
 

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -184,8 +184,15 @@ public class RecipeScanService {
     }
 
     private static boolean hasUsableRecipes(List<ImportedRecipePreview> recipes) {
-        return recipes != null && !recipes.isEmpty()
-                && recipes.stream().anyMatch(r -> r.ingredients() != null && !r.ingredients().isEmpty());
+        if (recipes == null || recipes.isEmpty()) return false;
+        return recipes.stream().anyMatch(r -> {
+            if (r.ingredients() == null || r.ingredients().isEmpty()) return false;
+            long wholeCount = r.ingredients().stream()
+                    .filter(i -> "WHOLE".equals(i.unit()))
+                    .count();
+            // If >75% of ingredients are WHOLE, the model likely failed to read units
+            return wholeCount <= r.ingredients().size() * 0.75;
+        });
     }
 
     private ScanResult saveScanSession(String orgId, byte[] imageBytes, String imageContentType,

--- a/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeScanService.java
@@ -187,11 +187,12 @@ public class RecipeScanService {
         if (recipes == null || recipes.isEmpty()) return false;
         return recipes.stream().anyMatch(r -> {
             if (r.ingredients() == null || r.ingredients().isEmpty()) return false;
+            int total = r.ingredients().size();
+            if (total <= 2) return true;
             long wholeCount = r.ingredients().stream()
                     .filter(i -> "WHOLE".equals(i.unit()))
                     .count();
-            // If >75% of ingredients are WHOLE, the model likely failed to read units
-            return wholeCount <= r.ingredients().size() * 0.75;
+            return wholeCount * 4 < total * 3;
         });
     }
 


### PR DESCRIPTION
## Summary

Improves extraction accuracy for handwritten recipe cards by strengthening LLM prompts and adding a quality gate that forces fallback to the text LLM when the vision model fails to read unit abbreviations.

### Changes
- **Handwritten unit abbreviation rules**: Added explicit CRITICAL rules with examples for single-letter abbreviations (`t`=TSP, `T`=TBSP, `c`=CUP) in both vision and text prompts
- **Multi-column serving size rule**: Instructs the model to extract only the first (smallest) column from scaling tables
- **Section-vs-ingredient clarity**: Strengthened vision prompt to prevent ingredient names from being used as section headers
- **WHOLE-unit quality gate**: If >75% of extracted ingredients have WHOLE unit, the extraction is rejected and falls through to the VISION_TEXT tier where the text LLM can better interpret abbreviations

### Test Results (before → after)
| Recipe | Before | After |
|--------|--------|-------|
| Chicken Caesar Salad | 10 WHOLE, 1 CUP, 1 LBS | 6 TSP, 2 CUP, 2 WHOLE, 1 LBS |
| Waffles | sections=Butter,Dry,Egg Whites,Milk + dupes | no sections, no dupes |
| Pancakes (regression check) | 3 CUP, 3 TSP, 2 TBSP, 1 WHOLE | 3 CUP, 4 TSP, 1 WHOLE (maintained) |

## Test plan
- [x] Chicken Caesar Salad: units now correctly mapped from handwritten abbreviations
- [x] Waffles: ingredient-name sections eliminated, no duplicate ingredients
- [x] Pancakes: no regression on clean recipes
- [x] Stromboli: maintained quality with correct sections (Dough/Filling)
- [x] Lasagna: maintained quality