### PR TITLE
Switch to qwen3.5:9b + qwen3:14b model combo

### DIFF
--- a/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
+++ b/src/main/java/com/endoran/foodplan/service/OllamaRecipeExtractor.java
@@ -164,8 +164,8 @@ public class OllamaRecipeExtractor {
     public OllamaRecipeExtractor(
             @Value("${ollama.host:}") String host,
             @Value("${ollama.port:11434}") int port,
-            @Value("${ollama.vision-model:qwen2.5vl:32b}") String visionModel,
-            @Value("${ollama.text-model:qwen2.5:32b-instruct-q4_K_M}") String textModel,
+            @Value("${ollama.vision-model:qwen3.5:9b}") String visionModel,
+            @Value("${ollama.text-model:qwen3:14b}") String textModel,
             @Value("${ollama.timeout:300}") int timeout,
             ObjectMapper objectMapper,
             RecipeImportService recipeImportService) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,8 +38,8 @@ store.maxAlternatives=${STORE_MAX_ALTERNATIVES:8}
 # Ollama LLM (recipe scan extraction)
 ollama.host=${OLLAMA_HOST:}
 ollama.port=${OLLAMA_PORT:11434}
-ollama.vision-model=${OLLAMA_VISION_MODEL:qwen2.5vl:32b}
-ollama.text-model=${OLLAMA_TEXT_MODEL:qwen2.5:32b-instruct-q4_K_M}
+ollama.vision-model=${OLLAMA_VISION_MODEL:qwen3.5:9b}
+ollama.text-model=${OLLAMA_TEXT_MODEL:qwen3:14b}
 ollama.timeout=${OLLAMA_TIMEOUT:300}
 
 # Global Recipe Book (cross-instance sharing)


### PR DESCRIPTION
## Summary
- Replace 32B models (OOM on 36GB Mac) with benchmarked combo: **qwen3.5:9b** (vision) + **qwen3:14b** (text)
- Combined memory footprint: 15.9GB (vs 40GB), both models stay resident simultaneously
- qwen3.5:9b scored 92/100 on extraction quality with **zero hallucinations** across 21 recipe images
- qwen3:14b scored 100/100 on text→JSON structuring

## Benchmark Data
| Model | Score | Time | Hallucination Rate |
|---|---|---|---|
| gemma3:12b | 95 | 13.0s | 29% (6/21 images) |
| **qwen3.5:9b** | **92** | **21.6s** | **0%** |
| qwen2.5vl:7b | 90 | 23.7s | not tested |
| ministral-3:14b | 77 | 22.2s | not tested |
| qwen3-vl:8b | 0 | 154.8s | N/A (no valid JSON) |
| llama3.2-vision:11b | 0 | 212.3s | N/A |

## Test plan
- [ ] Build and deploy to k3s
- [ ] Scan a clean printed recipe (pancakes) — verify correct extraction
- [ ] Scan a handwritten recipe (chicken caesar) — verify faithful transcription
- [ ] Scan a multi-column recipe (waffles) — verify first-column extraction
- [ ] Verify VISION_TEXT fallback tier still works (vision raw text → qwen3:14b)
- [ ] Monitor memory: both models loaded < 20GB total