### PR TITLE
IMG-0 Fix scan crash on single-recipe results

### DIFF
--- a/frontend/src/recipes/RecipeScanPage.tsx
+++ b/frontend/src/recipes/RecipeScanPage.tsx
@@ -59,8 +59,8 @@ export function RecipeScanPage() {
   const [step, setStep] = useState<'upload' | 'select' | 'edit' | 'review'>('upload');
   const [newIngredients, setNewIngredients] = useState<IngredientPreparation[]>([]);
 
-  const loadRecipe = (index: number) => {
-    const recipe = recipes[index];
+  const loadRecipe = (index: number, source?: ImportedPreview[]) => {
+    const recipe = (source || recipes)[index];
     setSelectedIndex(index);
     setName(recipe.name);
     setInstructions(recipe.instructions);
@@ -102,7 +102,7 @@ export function RecipeScanPage() {
       if (data.recipes.length === 0) {
         setError('No recipes could be extracted from the image');
       } else if (data.recipes.length === 1) {
-        loadRecipe(0);
+        loadRecipe(0, data.recipes);
       } else {
         setStep('select');
       }


### PR DESCRIPTION
## Summary
- Fix React stale closure bug in RecipeScanPage.tsx
- loadRecipe(0) read from stale recipes state (still []) because React batches setRecipes
- Pass data.recipes directly so loadRecipe uses the fresh scan result

Fixes: "undefined is not an object (evaluating U.name)"

## Test plan
- [x] Scan single-recipe photo (jackies-lemonade.jpg) — loads edit form correctly
- [ ] Scan multi-recipe photo — selection step still works
- [ ] Scan unreadable photo — error message displays cleanly