### PR TITLE
#260 Fix fraction input + add Playwright E2E tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,8 @@
 node_modules/
 dist/
 .DS_Store
+
+# Playwright
+e2e/.auth/
+e2e/test-results/
+e2e/.env.local

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  timeout: 30_000,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:9090',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /global-setup\.ts/,
+    },
+    {
+      name: 'desktop-chrome',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: join(__dirname, '.auth', 'user.json'),
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'iphone-safari',
+      use: {
+        ...devices['iPhone 15'],
+        storageState: join(__dirname, '.auth', 'user.json'),
+      },
+      dependencies: ['setup'],
+    },
+  ],
+  outputDir: join(__dirname, 'test-results'),
+});

--- a/frontend/e2e/run-tests.sh
+++ b/frontend/e2e/run-tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
-export PATH=/opt/homebrew/bin:$PATH
+
+# Portable PATH: add Homebrew if present (ARM or Intel Mac)
+[ -d /opt/homebrew/bin ] && export PATH=/opt/homebrew/bin:$PATH
+[ -d /usr/local/bin ] && export PATH=/usr/local/bin:$PATH
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/frontend/e2e/run-tests.sh
+++ b/frontend/e2e/run-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+export PATH=/opt/homebrew/bin:$PATH
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env.local" ]; then
+  set -a
+  source "$SCRIPT_DIR/.env.local"
+  set +a
+fi
+
+NAMESPACE="${K8S_NAMESPACE:-home-staging}"
+TENANT="${K8S_TENANT:-test10}"
+LOCAL_PORT="${LOCAL_PORT:-9090}"
+
+echo "Starting port-forward to $TENANT in $NAMESPACE on :$LOCAL_PORT..."
+kubectl -n "$NAMESPACE" port-forward "svc/foodplan-${TENANT}-frontend" "${LOCAL_PORT}:80" &
+PF_PID=$!
+trap "kill $PF_PID 2>/dev/null || true" EXIT
+
+for i in $(seq 1 15); do
+  if curl -s -o /dev/null "http://localhost:${LOCAL_PORT}/" 2>/dev/null; then
+    echo "Port-forward ready."
+    break
+  fi
+  if [ "$i" -eq 15 ]; then
+    echo "ERROR: Port-forward failed to become ready after 15s"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Running Playwright tests..."
+cd "$SCRIPT_DIR/.."
+BASE_URL="http://localhost:${LOCAL_PORT}" npx playwright test --config e2e/playwright.config.ts "$@"

--- a/frontend/e2e/tests/calendar.spec.ts
+++ b/frontend/e2e/tests/calendar.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Calendar', () => {
+  test('calendar page loads', async ({ page }) => {
+    await page.goto('/calendar');
+    await expect(page.locator('.calendar, .week-view, .month-view, [class*="calendar"]')).toBeVisible({ timeout: 5_000 }).catch(async () => {
+      await expect(page.locator('body')).toContainText(/\d{4}/);
+    });
+  });
+});

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -1,0 +1,39 @@
+import { test as setup, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const authFile = join(__dirname, '..', '.auth', 'user.json');
+
+setup('authenticate', async ({ page }) => {
+  const email = process.env.TEST_EMAIL;
+  const password = process.env.TEST_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error('TEST_EMAIL and TEST_PASSWORD env vars required. Set them in e2e/.env.local');
+  }
+
+  page.on('response', resp => {
+    if (resp.url().includes('/auth/login')) {
+      console.log('Login response:', resp.status(), resp.url());
+    }
+  });
+
+  await page.goto('/login');
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+
+  const [response] = await Promise.all([
+    page.waitForResponse(resp => resp.url().includes('/auth/login')),
+    page.getByRole('button', { name: /sign in/i }).click(),
+  ]);
+
+  console.log('Login API status:', response.status());
+  if (response.status() !== 200) {
+    const body = await response.text();
+    console.log('Login API body:', body);
+  }
+
+  await expect(page).toHaveURL(/\/recipes/, { timeout: 10_000 });
+  await page.context().storageState({ path: authFile });
+});

--- a/frontend/e2e/tests/inventory.spec.ts
+++ b/frontend/e2e/tests/inventory.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Inventory', () => {
+  test('inventory page loads', async ({ page }) => {
+    await page.goto('/inventory');
+    await expect(page.getByRole('heading')).toBeVisible();
+  });
+
+  test('quantity field accepts fractions', async ({ page }) => {
+    await page.goto('/inventory');
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    if (await qtyInput.isVisible().catch(() => false)) {
+      await qtyInput.fill('3/4');
+      await expect(qtyInput).toHaveValue('3/4');
+    }
+  });
+});

--- a/frontend/e2e/tests/inventory.spec.ts
+++ b/frontend/e2e/tests/inventory.spec.ts
@@ -8,10 +8,13 @@ test.describe('Inventory', () => {
 
   test('quantity field accepts fractions', async ({ page }) => {
     await page.goto('/inventory');
-    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
-    if (await qtyInput.isVisible().catch(() => false)) {
-      await qtyInput.fill('3/4');
-      await expect(qtyInput).toHaveValue('3/4');
+    const addBtn = page.getByRole('button', { name: /add item/i });
+    if (await addBtn.isVisible().catch(() => false)) {
+      await addBtn.click();
     }
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    await expect(qtyInput).toBeVisible({ timeout: 5_000 });
+    await qtyInput.fill('3/4');
+    await expect(qtyInput).toHaveValue('3/4');
   });
 });

--- a/frontend/e2e/tests/quick-cook.spec.ts
+++ b/frontend/e2e/tests/quick-cook.spec.ts
@@ -9,9 +9,8 @@ test.describe('Quick Cook', () => {
   test('quantity field accepts fractions', async ({ page }) => {
     await page.goto('/quick-cook');
     const qtyInput = page.locator('input[placeholder*="1/2"]').first();
-    if (await qtyInput.isVisible().catch(() => false)) {
-      await qtyInput.fill('1/4');
-      await expect(qtyInput).toHaveValue('1/4');
-    }
+    await expect(qtyInput).toBeVisible({ timeout: 5_000 });
+    await qtyInput.fill('1/4');
+    await expect(qtyInput).toHaveValue('1/4');
   });
 });

--- a/frontend/e2e/tests/quick-cook.spec.ts
+++ b/frontend/e2e/tests/quick-cook.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Quick Cook', () => {
+  test('quick cook page loads', async ({ page }) => {
+    await page.goto('/quick-cook');
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+
+  test('quantity field accepts fractions', async ({ page }) => {
+    await page.goto('/quick-cook');
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    if (await qtyInput.isVisible().catch(() => false)) {
+      await qtyInput.fill('1/4');
+      await expect(qtyInput).toHaveValue('1/4');
+    }
+  });
+});

--- a/frontend/e2e/tests/recipe-form.spec.ts
+++ b/frontend/e2e/tests/recipe-form.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Recipe Form — fraction input (#260)', () => {
+test.describe('Recipe Form \u2014 fraction input (#260)', () => {
   test('accepts simple fraction in quantity field', async ({ page }) => {
     await page.goto('/recipes/new');
     await page.getByRole('button', { name: /add ingredient/i }).click();
@@ -26,8 +26,9 @@ test.describe('Recipe Form — fraction input (#260)', () => {
   });
 });
 
-test.describe('Recipe Form — servings clearing (#264)', () => {
-  test.fail('servings field can be cleared and retyped — KNOWN BUG #264', async ({ page }) => {
+test.describe('Recipe Form \u2014 servings clearing (#264)', () => {
+  // When #264 is fixed, REMOVE test.fail or this test will start failing
+  test.fail('servings field can be cleared and retyped \u2014 KNOWN BUG #264', async ({ page }) => {
     await page.goto('/recipes/new');
     const servingsInput = page.locator('input[type="number"]').first();
     await expect(servingsInput).toBeVisible();

--- a/frontend/e2e/tests/recipe-form.spec.ts
+++ b/frontend/e2e/tests/recipe-form.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Recipe Form — fraction input (#260)', () => {
+  test('accepts simple fraction in quantity field', async ({ page }) => {
+    await page.goto('/recipes/new');
+    await page.getByRole('button', { name: /add ingredient/i }).click();
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    await qtyInput.fill('1/2');
+    await expect(qtyInput).toHaveValue('1/2');
+  });
+
+  test('accepts mixed fraction in quantity field', async ({ page }) => {
+    await page.goto('/recipes/new');
+    await page.getByRole('button', { name: /add ingredient/i }).click();
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    await qtyInput.fill('1 1/2');
+    await expect(qtyInput).toHaveValue('1 1/2');
+  });
+
+  test('accepts decimal in quantity field', async ({ page }) => {
+    await page.goto('/recipes/new');
+    await page.getByRole('button', { name: /add ingredient/i }).click();
+    const qtyInput = page.locator('input[placeholder*="1/2"]').first();
+    await qtyInput.fill('2.5');
+    await expect(qtyInput).toHaveValue('2.5');
+  });
+});
+
+test.describe('Recipe Form — servings clearing (#264)', () => {
+  test.fail('servings field can be cleared and retyped — KNOWN BUG #264', async ({ page }) => {
+    await page.goto('/recipes/new');
+    const servingsInput = page.locator('input[type="number"]').first();
+    await expect(servingsInput).toBeVisible();
+    await servingsInput.fill('');
+    await servingsInput.pressSequentially('4');
+    await expect(servingsInput).toHaveValue('4');
+  });
+});

--- a/frontend/e2e/tests/recipe-import.spec.ts
+++ b/frontend/e2e/tests/recipe-import.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Recipe Import', () => {
+  test('import page loads with URL input', async ({ page }) => {
+    await page.goto('/recipes/import');
+    await expect(page.locator('input[type="url"]')).toBeVisible();
+  });
+});

--- a/frontend/e2e/tests/recipe-scan.spec.ts
+++ b/frontend/e2e/tests/recipe-scan.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Recipe Scan', () => {
+  test('scan page loads with upload form', async ({ page }) => {
+    await page.goto('/recipes/scan');
+    await expect(page.locator('input[type="file"]')).toBeVisible();
+  });
+
+  test('scan button enables after file selection', async ({ page }) => {
+    await page.goto('/recipes/scan');
+    const fileInput = page.locator('input[type="file"]');
+    const buffer = Buffer.from('fake-image-data');
+    await fileInput.setInputFiles({
+      name: 'test-recipe.jpg',
+      mimeType: 'image/jpeg',
+      buffer,
+    });
+    await expect(page.getByRole('button', { name: /scan/i })).toBeEnabled();
+  });
+});

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1168,6 +1169,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1212,6 +1220,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1259,6 +1285,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1329,6 +1478,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1381,6 +1540,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1431,6 +1597,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1519,6 +1705,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1549,6 +1745,24 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1784,6 +1998,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1792,6 +2013,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1809,6 +2061,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1929,6 +2191,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -794,6 +795,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1553,6 +1570,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:desktop": "playwright test --config e2e/playwright.config.ts --project desktop-chrome",
     "test:e2e:iphone": "playwright test --config e2e/playwright.config.ts --project iphone-safari"
@@ -22,6 +23,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test --config e2e/playwright.config.ts",
+    "test:e2e:desktop": "playwright test --config e2e/playwright.config.ts --project desktop-chrome",
+    "test:e2e:iphone": "playwright test --config e2e/playwright.config.ts --project iphone-safari"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -14,6 +17,7 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/frontend/src/inventory/InventoryPage.tsx
+++ b/frontend/src/inventory/InventoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { parseFraction } from '../utils/parseFraction';
 import { apiGet, apiPost, apiPut, apiDelete } from '../api/client';
 import type { Ingredient } from '../recipes/types';
 import type { InventoryItem } from './types';
@@ -35,10 +36,13 @@ export function InventoryPage() {
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+    const qty = parseFraction(newQuantity);
+    if (isNaN(qty)) { setError('Invalid quantity — use a number or fraction (e.g. 1/2)'); return; }
+
     try {
       await apiPost('/api/v1/inventory', {
         ingredientId: newIngredientId,
-        quantity: parseFloat(newQuantity),
+        quantity: qty,
         unit: newUnit,
       });
       setAdding(false);
@@ -61,7 +65,7 @@ export function InventoryPage() {
     setError('');
     try {
       await apiPut(`/api/v1/inventory/${id}`, {
-        quantity: parseFloat(editQuantity),
+        quantity: parseFraction(editQuantity),
         unit: editUnit,
       });
       setEditId(null);
@@ -109,12 +113,10 @@ export function InventoryPage() {
               </td>
               <td>
                 <input
-                  type="number"
+                  type="text"
                   value={newQuantity}
                   onChange={e => setNewQuantity(e.target.value)}
-                  placeholder="Qty"
-                  step="0.01"
-                  min="0.01"
+                  placeholder="Qty (e.g. 1/2)"
                   required
                   style={{ width: '80px' }}
                 />
@@ -138,11 +140,9 @@ export function InventoryPage() {
               <td>
                 {editId === item.id ? (
                   <input
-                    type="number"
+                    type="text"
                     value={editQuantity}
                     onChange={e => setEditQuantity(e.target.value)}
-                    step="0.01"
-                    min="0.01"
                     style={{ width: '80px' }}
                   />
                 ) : item.quantity}

--- a/frontend/src/inventory/InventoryPage.tsx
+++ b/frontend/src/inventory/InventoryPage.tsx
@@ -37,7 +37,7 @@ export function InventoryPage() {
     e.preventDefault();
     setError('');
     const qty = parseFraction(newQuantity);
-    if (isNaN(qty)) { setError('Invalid quantity — use a number or fraction (e.g. 1/2)'); return; }
+    if (isNaN(qty) || qty <= 0) { setError('Invalid quantity — use a number or fraction (e.g. 1/2)'); return; }
 
     try {
       await apiPost('/api/v1/inventory', {
@@ -63,9 +63,11 @@ export function InventoryPage() {
 
   const handleUpdate = async (id: string) => {
     setError('');
+    const qty = parseFraction(editQuantity);
+    if (isNaN(qty) || qty <= 0) { setError('Invalid quantity \u2014 use a number or fraction (e.g. 1/2)'); return; }
     try {
       await apiPut(`/api/v1/inventory/${id}`, {
-        quantity: parseFraction(editQuantity),
+        quantity: qty,
         unit: editUnit,
       });
       setEditId(null);

--- a/frontend/src/inventory/QuickCookPage.tsx
+++ b/frontend/src/inventory/QuickCookPage.tsx
@@ -50,7 +50,7 @@ export function QuickCookPage() {
         unit: r.unit,
       }));
 
-    if (items.some(item => isNaN(item.quantity))) {
+    if (items.some(item => isNaN(item.quantity) || item.quantity <= 0)) {
       setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
       return;
     }

--- a/frontend/src/inventory/QuickCookPage.tsx
+++ b/frontend/src/inventory/QuickCookPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { parseFraction } from '../utils/parseFraction';
 import { apiGet, apiPost } from '../api/client';
 import type { Ingredient } from '../recipes/types';
 
@@ -45,9 +46,14 @@ export function QuickCookPage() {
       .filter(r => r.ingredientId && r.quantity)
       .map(r => ({
         ingredientId: r.ingredientId,
-        quantity: parseFloat(r.quantity),
+        quantity: parseFraction(r.quantity),
         unit: r.unit,
       }));
+
+    if (items.some(item => isNaN(item.quantity))) {
+      setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
+      return;
+    }
 
     if (items.length === 0) {
       setError('Add at least one ingredient');
@@ -97,12 +103,10 @@ export function QuickCookPage() {
                 ))}
               </select>
               <input
-                type="number"
-                placeholder="Qty"
+                type="text"
+                placeholder="Qty (e.g. 1/2)"
                 value={row.quantity}
                 onChange={e => updateRow(i, 'quantity', e.target.value)}
-                step="0.01"
-                min="0.01"
                 required
               />
               <select value={row.unit} onChange={e => updateRow(i, 'unit', e.target.value)}>

--- a/frontend/src/recipes/RecipeFormPage.tsx
+++ b/frontend/src/recipes/RecipeFormPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { apiGet, apiPost, apiPut } from '../api/client';
 import type { Recipe, Ingredient } from './types';
+import { parseFraction } from '../utils/parseFraction';
 
 interface IngredientRow {
   section: string;
@@ -169,19 +170,27 @@ export function RecipeFormPage() {
       return;
     }
 
+    const parsed = ingredients
+      .filter(row => (row.ingredientId || row.ingredientName) && row.quantity)
+      .map(row => ({
+        section: row.section || null,
+        ingredientId: row.ingredientId,
+        ingredientName: row.ingredientName,
+        quantity: parseFraction(row.quantity),
+        unit: row.unit,
+      }));
+
+    if (parsed.some(ing => isNaN(ing.quantity))) {
+      setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
+      setLoading(false);
+      return;
+    }
+
     const body = {
       name,
       instructions: instructions || null,
       baseServings,
-      ingredients: ingredients
-        .filter(row => (row.ingredientId || row.ingredientName) && row.quantity)
-        .map(row => ({
-          section: row.section || null,
-          ingredientId: row.ingredientId,
-          ingredientName: row.ingredientName,
-          quantity: parseFloat(row.quantity),
-          unit: row.unit,
-        })),
+      ingredients: parsed,
     };
 
     try {
@@ -265,12 +274,10 @@ export function RecipeFormPage() {
                         }}
                       />
                       <input
-                        type="number"
-                        placeholder="Qty"
+                        type="text"
+                        placeholder="Qty (e.g. 1/2)"
                         value={row.quantity}
                         onChange={e => updateRow(i, 'quantity', e.target.value)}
-                        step="0.01"
-                        min="0.01"
                         required
                       />
                       <select value={row.unit} onChange={e => updateRow(i, 'unit', e.target.value)}>

--- a/frontend/src/recipes/RecipeFormPage.tsx
+++ b/frontend/src/recipes/RecipeFormPage.tsx
@@ -180,7 +180,7 @@ export function RecipeFormPage() {
         unit: row.unit,
       }));
 
-    if (parsed.some(ing => isNaN(ing.quantity))) {
+    if (parsed.some(ing => isNaN(ing.quantity) || ing.quantity <= 0)) {
       setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
       setLoading(false);
       return;

--- a/frontend/src/recipes/RecipeImportPage.tsx
+++ b/frontend/src/recipes/RecipeImportPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiPost } from '../api/client';
+import { parseFraction } from '../utils/parseFraction';
 import { formatEnum } from '../utils/formatEnum';
 
 interface ImportedIngredient {
@@ -107,16 +108,23 @@ export function RecipeImportPage() {
       return;
     }
 
+    const parsed = ingredients.map(ing => ({
+      ingredientId: '',
+      ingredientName: ing.name,
+      quantity: typeof ing.quantity === 'string' ? parseFraction(ing.quantity) : ing.quantity,
+      unit: ing.unit,
+    }));
+
+    if (parsed.some(ing => isNaN(ing.quantity))) {
+      setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
+      return;
+    }
+
     const body = {
       name,
       instructions: instructions || null,
       baseServings,
-      ingredients: ingredients.map(ing => ({
-        ingredientId: '',
-        ingredientName: ing.name,
-        quantity: ing.quantity,
-        unit: ing.unit,
-      })),
+      ingredients: parsed,
     };
     const created = await apiPost<{ id: string }>('/api/v1/recipes', body);
     navigate(`/recipes/${created.id}`);
@@ -218,11 +226,10 @@ export function RecipeImportPage() {
                     )}
                   </div>
                   <input
-                    type="number"
+                    type="text"
                     value={ing.quantity}
-                    onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
-                    step="0.01"
-                    min="0"
+                    onChange={e => updateIngredient(i, 'quantity', e.target.value)}
+                    placeholder="e.g. 1/2"
                     style={{ flex: 1 }}
                   />
                   <select

--- a/frontend/src/recipes/RecipeImportPage.tsx
+++ b/frontend/src/recipes/RecipeImportPage.tsx
@@ -6,7 +6,7 @@ import { formatEnum } from '../utils/formatEnum';
 
 interface ImportedIngredient {
   name: string;
-  quantity: number;
+  quantity: number | string;
   unit: string;
   rawText: string;
   prepNote?: string;
@@ -115,7 +115,7 @@ export function RecipeImportPage() {
       unit: ing.unit,
     }));
 
-    if (parsed.some(ing => isNaN(ing.quantity))) {
+    if (parsed.some(ing => isNaN(ing.quantity) || ing.quantity <= 0)) {
       setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
       return;
     }

--- a/frontend/src/recipes/RecipeScanPage.tsx
+++ b/frontend/src/recipes/RecipeScanPage.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiPost } from '../api/client';
+import { parseFraction } from '../utils/parseFraction';
 import { formatEnum } from '../utils/formatEnum';
 
 interface ImportedIngredient {
   section: string | null;
   name: string;
-  quantity: number;
+  quantity: number | string;
   unit: string;
   rawText: string;
   prepNote?: string;
@@ -152,17 +153,24 @@ export function RecipeScanPage() {
       return;
     }
 
+    const parsed = ingredients.map(ing => ({
+      section: ing.section || null,
+      ingredientId: '',
+      ingredientName: ing.name,
+      quantity: typeof ing.quantity === 'string' ? parseFraction(ing.quantity) : ing.quantity,
+      unit: ing.unit,
+    }));
+
+    if (parsed.some(ing => isNaN(ing.quantity))) {
+      setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
+      return;
+    }
+
     const body: Record<string, unknown> = {
       name,
       instructions: instructions || null,
       baseServings,
-      ingredients: ingredients.map(ing => ({
-        section: ing.section || null,
-        ingredientId: '',
-        ingredientName: ing.name,
-        quantity: ing.quantity,
-        unit: ing.unit,
-      })),
+      ingredients: parsed,
     };
 
     // Include scan session metadata for training pair generation
@@ -350,11 +358,10 @@ export function RecipeScanPage() {
                               placeholder="Ingredient name"
                             />
                             <input
-                              type="number"
+                              type="text"
                               value={ing.quantity}
-                              onChange={e => updateIngredient(i, 'quantity', parseFloat(e.target.value) || 0)}
-                              step="0.01"
-                              min="0"
+                              onChange={e => updateIngredient(i, 'quantity', e.target.value)}
+                              placeholder="e.g. 1/2"
                               style={{ flex: 1 }}
                             />
                             <select

--- a/frontend/src/recipes/RecipeScanPage.tsx
+++ b/frontend/src/recipes/RecipeScanPage.tsx
@@ -161,7 +161,7 @@ export function RecipeScanPage() {
       unit: ing.unit,
     }));
 
-    if (parsed.some(ing => isNaN(ing.quantity))) {
+    if (parsed.some(ing => isNaN(ing.quantity) || ing.quantity <= 0)) {
       setError('Invalid quantity — use a number or fraction (e.g. 1/2)');
       return;
     }

--- a/frontend/src/utils/parseFraction.test.ts
+++ b/frontend/src/utils/parseFraction.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'vitest';
+import { parseFraction } from './parseFraction';
+
+describe('parseFraction', () => {
+  test('plain integers', () => {
+    expect(parseFraction('3')).toBe(3);
+    expect(parseFraction('0')).toBe(0);
+    expect(parseFraction('42')).toBe(42);
+  });
+
+  test('decimals', () => {
+    expect(parseFraction('2.5')).toBe(2.5);
+    expect(parseFraction('0.75')).toBe(0.75);
+  });
+
+  test('simple fractions', () => {
+    expect(parseFraction('1/2')).toBe(0.5);
+    expect(parseFraction('3/4')).toBe(0.75);
+    expect(parseFraction('1/3')).toBeCloseTo(0.333, 2);
+  });
+
+  test('mixed fractions', () => {
+    expect(parseFraction('1 1/2')).toBe(1.5);
+    expect(parseFraction('2 3/4')).toBe(2.75);
+    expect(parseFraction('10 1/3')).toBeCloseTo(10.333, 2);
+  });
+
+  test('unicode fractions', () => {
+    expect(parseFraction('\u00BD')).toBe(0.5);
+    expect(parseFraction('\u00BC')).toBe(0.25);
+    expect(parseFraction('\u00BE')).toBe(0.75);
+    expect(parseFraction('1\u00BD')).toBe(1.5);
+    expect(parseFraction('2\u00BC')).toBe(2.25);
+  });
+
+  test('whitespace handling', () => {
+    expect(parseFraction('  1/2  ')).toBe(0.5);
+    expect(parseFraction(' 3 ')).toBe(3);
+    expect(parseFraction('1  1/2')).toBe(1.5);
+  });
+
+  test('rejects negative numbers', () => {
+    expect(parseFraction('-1')).toBeNaN();
+    expect(parseFraction('-2.5')).toBeNaN();
+  });
+
+  test('rejects invalid input', () => {
+    expect(parseFraction('')).toBeNaN();
+    expect(parseFraction('abc')).toBeNaN();
+    expect(parseFraction('1/0')).toBeNaN();
+    expect(parseFraction('0/0')).toBeNaN();
+    expect(parseFraction('hello world')).toBeNaN();
+  });
+});

--- a/frontend/src/utils/parseFraction.ts
+++ b/frontend/src/utils/parseFraction.ts
@@ -1,0 +1,44 @@
+export function parseFraction(input: string): number {
+  const s = input.trim();
+  if (!s) return NaN;
+
+  // Plain number (integer or decimal)
+  if (/^-?\d+(\.\d+)?$/.test(s)) return parseFloat(s);
+
+  // Simple fraction: "1/2", "3/4"
+  const fractionMatch = s.match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (fractionMatch) {
+    const num = parseInt(fractionMatch[1]);
+    const den = parseInt(fractionMatch[2]);
+    return den === 0 ? NaN : num / den;
+  }
+
+  // Mixed fraction: "1 1/2", "2 3/4"
+  const mixedMatch = s.match(/^(\d+)\s+(\d+)\s*\/\s*(\d+)$/);
+  if (mixedMatch) {
+    const whole = parseInt(mixedMatch[1]);
+    const num = parseInt(mixedMatch[2]);
+    const den = parseInt(mixedMatch[3]);
+    return den === 0 ? NaN : whole + num / den;
+  }
+
+  // Unicode fractions
+  const unicodeFractions: Record<string, number> = {
+    "\u00BC": 0.25, "\u00BD": 0.5, "\u00BE": 0.75,
+    "\u2153": 1/3, "\u2154": 2/3, "\u2155": 0.2, "\u2156": 0.4,
+    "\u2157": 0.6, "\u2158": 0.8, "\u2159": 1/6, "\u215A": 5/6,
+    "\u215B": 0.125, "\u215C": 0.375, "\u215D": 0.625, "\u215E": 0.875,
+  };
+
+  // "1½" or just "½"
+  for (const [char, val] of Object.entries(unicodeFractions)) {
+    if (s.endsWith(char)) {
+      const prefix = s.slice(0, -1).trim();
+      if (!prefix) return val;
+      const whole = parseInt(prefix);
+      return isNaN(whole) ? NaN : whole + val;
+    }
+  }
+
+  return NaN;
+}

--- a/frontend/src/utils/parseFraction.ts
+++ b/frontend/src/utils/parseFraction.ts
@@ -2,10 +2,8 @@ export function parseFraction(input: string): number {
   const s = input.trim();
   if (!s) return NaN;
 
-  // Plain number (integer or decimal)
-  if (/^-?\d+(\.\d+)?$/.test(s)) return parseFloat(s);
+  if (/^\d+(\.\d+)?$/.test(s)) return parseFloat(s);
 
-  // Simple fraction: "1/2", "3/4"
   const fractionMatch = s.match(/^(\d+)\s*\/\s*(\d+)$/);
   if (fractionMatch) {
     const num = parseInt(fractionMatch[1]);
@@ -13,7 +11,6 @@ export function parseFraction(input: string): number {
     return den === 0 ? NaN : num / den;
   }
 
-  // Mixed fraction: "1 1/2", "2 3/4"
   const mixedMatch = s.match(/^(\d+)\s+(\d+)\s*\/\s*(\d+)$/);
   if (mixedMatch) {
     const whole = parseInt(mixedMatch[1]);
@@ -22,7 +19,6 @@ export function parseFraction(input: string): number {
     return den === 0 ? NaN : whole + num / den;
   }
 
-  // Unicode fractions
   const unicodeFractions: Record<string, number> = {
     "\u00BC": 0.25, "\u00BD": 0.5, "\u00BE": 0.75,
     "\u2153": 1/3, "\u2154": 2/3, "\u2155": 0.2, "\u2156": 0.4,
@@ -30,7 +26,6 @@ export function parseFraction(input: string): number {
     "\u215B": 0.125, "\u215C": 0.375, "\u215D": 0.625, "\u215E": 0.875,
   };
 
-  // "1½" or just "½"
   for (const [char, val] of Object.entries(unicodeFractions)) {
     if (s.endsWith(char)) {
       const prefix = s.slice(0, -1).trim();


### PR DESCRIPTION
## Summary

- **Fraction input fix (#260)**: All 5 quantity input fields changed from `type="number"` to `type="text"` so users can enter fractions like `1/2` or `1 1/2` on any device including iOS. Shared `parseFraction` utility converts to numbers at submit time.

- **Playwright E2E test suite (#265)**: Headless browser testing with Desktop Chrome and iPhone 15 Safari (WebKit). Tests hit real staging backend (test10) via kubectl port-forward. Auth uses storageState for session reuse. Includes `run-tests.sh` wrapper.

## Test results

25/25 passing (Desktop Chrome + iPhone Safari):
- Page-load smoke tests for all major pages
- Fraction input acceptance on recipe form, inventory, quick cook
- Servings clearing regression (#264) — marked as known-fail, confirms the bug

## Affected pages

RecipeScanPage, RecipeImportPage, RecipeFormPage, QuickCookPage, InventoryPage

## Test plan

- [x] Playwright suite passes: 25/25 (2 expected-fail for #264)
- [x] Fraction input works on Desktop Chrome
- [x] Fraction input works on iPhone 15 Safari (WebKit)
- [ ] Manual test on real iOS device