### PR TITLE
#259 #261 Live ingredient search + configurable recipe search sites

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { CalendarPage } from './calendar/CalendarPage';
 import { InventoryPage } from './inventory/InventoryPage';
 import { ShoppingListPage } from './inventory/ShoppingListPage';
 import { QuickCookPage } from './inventory/QuickCookPage';
+import { SettingsPage } from './settings/SettingsPage';
 
 export function App() {
   return (
@@ -43,6 +44,7 @@ export function App() {
             <Route path="/inventory" element={<ProtectedRoute><InventoryPage /></ProtectedRoute>} />
             <Route path="/shopping-list" element={<ProtectedRoute><ShoppingListPage /></ProtectedRoute>} />
             <Route path="/quick-cook" element={<ProtectedRoute><QuickCookPage /></ProtectedRoute>} />
+            <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
             <Route path="/" element={<Navigate to="/recipes" replace />} />
           </Route>
         </Routes>

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,22 @@
+import { apiGet, apiPut } from './client';
+
+export interface OrgSettings {
+  timezone: string;
+  defaultServings: number;
+  allowedRecipeSites: string[];
+  defaultRecipeSites: string[];
+}
+
+export interface UpdateOrgSettingsRequest {
+  timezone?: string;
+  defaultServings?: number;
+  allowedRecipeSites?: string[];
+}
+
+export function getSettings(): Promise<OrgSettings> {
+  return apiGet('/api/v1/settings');
+}
+
+export function updateSettings(req: UpdateOrgSettingsRequest): Promise<OrgSettings> {
+  return apiPut('/api/v1/settings', req);
+}

--- a/frontend/src/layout/NavBar.tsx
+++ b/frontend/src/layout/NavBar.tsx
@@ -21,6 +21,7 @@ export function NavBar() {
           <Link to="/inventory">Pantry</Link>
           <Link to="/quick-cook">Quick Cook</Link>
           <Link to="/shopping-list">Shopping List</Link>
+          <Link to="/settings">Settings</Link>
           <span className="nav-user">{user?.email}</span>
           <button onClick={handleLogout} className="btn btn-small">Logout</button>
         </div>

--- a/frontend/src/recipes/IngredientListPage.tsx
+++ b/frontend/src/recipes/IngredientListPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { apiGet, apiDelete } from '../api/client';
 import { formatEnum } from '../utils/formatEnum';
@@ -7,23 +7,33 @@ import type { Ingredient } from './types';
 export function IngredientListPage() {
   const [ingredients, setIngredients] = useState<Ingredient[]>([]);
   const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = async () => {
-    const params = search ? `?name=${encodeURIComponent(search)}` : '';
-    const data = await apiGet<Ingredient[]>(`/api/v1/ingredients${params}`);
-    setIngredients(data);
+  const load = async (name?: string) => {
+    setLoading(true);
+    try {
+      const params = name ? `?name=${encodeURIComponent(name)}` : '';
+      const data = await apiGet<Ingredient[]>(`/api/v1/ingredients${params}`);
+      setIngredients(data);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => { load(); }, []);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    load();
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      load(value || undefined);
+    }, 300);
   };
 
   const handleDelete = async (id: string) => {
     await apiDelete(`/api/v1/ingredients/${id}`);
-    load();
+    load(search || undefined);
   };
 
   return (
@@ -36,49 +46,52 @@ export function IngredientListPage() {
         </div>
       </div>
 
-      <form className="search-bar" onSubmit={handleSearch}>
+      <div className="search-bar">
         <input
           type="text"
           placeholder="Search ingredients..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => handleSearchChange(e.target.value)}
         />
-        <button type="submit" className="btn">Search</button>
-      </form>
+      </div>
 
-      <table className="ingredients-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Grocery</th>
-            <th>Storage</th>
-            <th>Dietary Tags</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {ingredients.map(ing => (
-            <tr key={ing.id}>
-              <td>
-                <Link to={`/ingredients/${ing.id}/edit`}>{ing.name}</Link>
-                {ing.needsReview && <span className="review-badge">needs review</span>}
-              </td>
-              <td>{formatEnum(ing.groceryCategory)}</td>
-              <td>{formatEnum(ing.storageCategory)}</td>
-              <td>{ing.dietaryTags.length > 0 ? ing.dietaryTags.join(', ') : <span className="muted">none</span>}</td>
-              <td>
-                <div className="btn-group">
-                  <Link to={`/ingredients/${ing.id}/edit`} className="btn btn-small">Edit</Link>
-                  <button className="btn btn-danger btn-small" onClick={() => handleDelete(ing.id)}>Delete</button>
-                </div>
-              </td>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table className="ingredients-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Grocery</th>
+              <th>Storage</th>
+              <th>Dietary Tags</th>
+              <th></th>
             </tr>
-          ))}
-          {ingredients.length === 0 && (
-            <tr><td colSpan={5} className="empty">No ingredients found</td></tr>
-          )}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {ingredients.map(ing => (
+              <tr key={ing.id}>
+                <td>
+                  <Link to={`/ingredients/${ing.id}/edit`}>{ing.name}</Link>
+                  {ing.needsReview && <span className="review-badge">needs review</span>}
+                </td>
+                <td>{formatEnum(ing.groceryCategory)}</td>
+                <td>{formatEnum(ing.storageCategory)}</td>
+                <td>{ing.dietaryTags.length > 0 ? ing.dietaryTags.join(', ') : <span className="muted">none</span>}</td>
+                <td>
+                  <div className="btn-group">
+                    <Link to={`/ingredients/${ing.id}/edit`} className="btn btn-small">Edit</Link>
+                    <button className="btn btn-danger btn-small" onClick={() => handleDelete(ing.id)}>Delete</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {ingredients.length === 0 && (
+              <tr><td colSpan={5} className="empty">No ingredients found</td></tr>
+            )}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/frontend/src/recipes/RecipeFormPage.tsx
+++ b/frontend/src/recipes/RecipeFormPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { apiGet, apiPost, apiPut } from '../api/client';
 import type { Recipe, Ingredient } from './types';
@@ -13,6 +13,106 @@ interface IngredientRow {
 
 const UNITS = ['TSP', 'TBSP', 'CUP', 'PINT', 'QUART', 'GALLON', 'HALF_GALLON', 'WHOLE', 'LBS', 'OZ', 'PINCH', 'PIECE'];
 
+function IngredientAutocomplete({ value, onSelect }: {
+  value: string;
+  onSelect: (id: string, name: string) => void;
+}) {
+  const [query, setQuery] = useState(value);
+  const [suggestions, setSuggestions] = useState<Ingredient[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => { setQuery(value); }, [value]);
+
+  useEffect(() => {
+    return () => { if (debounceRef.current !== null) clearTimeout(debounceRef.current); };
+  }, []);
+
+  const search = async (term: string) => {
+    if (!term || term.length < 1) {
+      setSuggestions([]);
+      setShowDropdown(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const data = await apiGet<Ingredient[]>(`/api/v1/ingredients?name=${encodeURIComponent(term)}`);
+      setSuggestions(data);
+      setShowDropdown(data.length > 0);
+      setHighlightIndex(-1);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (val: string) => {
+    setQuery(val);
+    if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(val), 300);
+  };
+
+  const selectItem = (ing: Ingredient) => {
+    setQuery(ing.name);
+    setShowDropdown(false);
+    onSelect(ing.id, ing.name);
+  };
+
+  const handleBlur = () => {
+    setTimeout(() => {
+      setShowDropdown(false);
+      if (query !== value) {
+        onSelect('', query);
+      }
+    }, 150);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!showDropdown) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightIndex(prev => Math.min(prev + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightIndex(prev => Math.max(prev - 1, 0));
+    } else if (e.key === 'Enter' && highlightIndex >= 0) {
+      e.preventDefault();
+      selectItem(suggestions[highlightIndex]);
+    } else if (e.key === 'Escape') {
+      setShowDropdown(false);
+    }
+  };
+
+  return (
+    <div className="autocomplete-wrap">
+      <input
+        type="text"
+        value={query}
+        onChange={e => handleChange(e.target.value)}
+        onFocus={() => { if (suggestions.length > 0) setShowDropdown(true); }}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder="Type ingredient name..."
+      />
+      {showDropdown && (
+        <div className="autocomplete-dropdown">
+          {loading && <div className="autocomplete-loading">Searching...</div>}
+          {suggestions.map((ing, i) => (
+            <div
+              key={ing.id}
+              className={`autocomplete-option${i === highlightIndex ? ' highlighted' : ''}`}
+              onMouseDown={e => { e.preventDefault(); selectItem(ing); }}
+            >
+              {ing.name}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function RecipeFormPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -22,19 +122,12 @@ export function RecipeFormPage() {
   const [instructions, setInstructions] = useState('');
   const [baseServings, setBaseServings] = useState(1);
   const [ingredients, setIngredients] = useState<IngredientRow[]>([]);
-  const [availableIngredients, setAvailableIngredients] = useState<Ingredient[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    loadIngredients();
     if (isEdit) loadRecipe();
   }, [id]);
-
-  const loadIngredients = async () => {
-    const data = await apiGet<Ingredient[]>('/api/v1/ingredients');
-    setAvailableIngredients(data);
-  };
 
   const loadRecipe = async () => {
     const recipe = await apiGet<Recipe>(`/api/v1/recipes/${id}`);
@@ -61,10 +154,6 @@ export function RecipeFormPage() {
   const updateRow = (index: number, field: keyof IngredientRow, value: string) => {
     const updated = [...ingredients];
     updated[index] = { ...updated[index], [field]: value };
-    if (field === 'ingredientId') {
-      const found = availableIngredients.find(i => i.id === value);
-      updated[index].ingredientName = found?.name || '';
-    }
     setIngredients(updated);
   };
 
@@ -103,7 +192,6 @@ export function RecipeFormPage() {
     }
   };
 
-  // Group ingredients by section for display
   const groups: { section: string; startIndex: number }[] = [];
   ingredients.forEach((ing, i) => {
     if (i === 0 || ing.section !== ingredients[i - 1].section) {
@@ -159,21 +247,16 @@ export function RecipeFormPage() {
                 )}
                 {groupRows.map((row, j) => {
                   const i = group.startIndex + j;
-                  // Try to match ingredientId from available list by name
-                  const matchedId = row.ingredientId || availableIngredients.find(
-                    a => a.name.toLowerCase() === row.ingredientName.toLowerCase()
-                  )?.id || '';
                   return (
                     <div key={i} className="ingredient-row">
-                      <select
-                        value={matchedId}
-                        onChange={e => updateRow(i, 'ingredientId', e.target.value)}
-                      >
-                        <option value="">{row.ingredientName || 'Select ingredient...'}</option>
-                        {availableIngredients.map(ing => (
-                          <option key={ing.id} value={ing.id}>{ing.name}</option>
-                        ))}
-                      </select>
+                      <IngredientAutocomplete
+                        value={row.ingredientName}
+                        onSelect={(selId, selName) => {
+                          const updated = [...ingredients];
+                          updated[i] = { ...updated[i], ingredientId: selId, ingredientName: selName };
+                          setIngredients(updated);
+                        }}
+                      />
                       <input
                         type="number"
                         placeholder="Qty"

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react';
+import { getSettings, updateSettings } from '../api/settings';
+
+export function SettingsPage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState('');
+
+  const [timezone, setTimezone] = useState('');
+  const [defaultServings, setDefaultServings] = useState('4');
+  const [sites, setSites] = useState<string[]>([]);
+  const [defaultSites, setDefaultSites] = useState<string[]>([]);
+  const [newSite, setNewSite] = useState('');
+
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    try {
+      const data = await getSettings();
+      setTimezone(data.timezone);
+      setDefaultServings(String(data.defaultServings));
+      setSites(data.allowedRecipeSites);
+      setDefaultSites(data.defaultRecipeSites);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const missingSuggestions = defaultSites.filter(s => !sites.includes(s));
+
+  const removeSite = (site: string) => {
+    setSites(sites.filter(s => s !== site));
+    setSaved(false);
+  };
+
+  const addSite = () => {
+    const domain = newSite.trim().toLowerCase()
+      .replace(/^https?:\/\//, '')
+      .replace(/^www\./, '')
+      .replace(/\/.*$/, '');
+    if (!domain || !/^[a-z0-9.-]+\.[a-z]{2,}$/.test(domain)) {
+      setError('Enter a valid domain (e.g. myrecipes.com)');
+      return;
+    }
+    if (sites.includes(domain)) {
+      setError('Site already in list');
+      return;
+    }
+    setError('');
+    setSites([...sites, domain]);
+    setNewSite('');
+    setSaved(false);
+  };
+
+  const addSuggestion = (site: string) => {
+    if (!sites.includes(site)) {
+      setSites([...sites, site]);
+      setSaved(false);
+    }
+  };
+
+  const resetToDefaults = () => {
+    setSites([...defaultSites]);
+    setSaved(false);
+  };
+
+  const handleSave = async () => {
+    setError('');
+    setSaving(true);
+    setSaved(false);
+    try {
+      const servings = parseInt(defaultServings);
+      if (isNaN(servings) || servings < 1) {
+        setError('Default servings must be at least 1');
+        return;
+      }
+      const data = await updateSettings({
+        timezone,
+        defaultServings: servings,
+        allowedRecipeSites: sites,
+      });
+      setTimezone(data.timezone);
+      setDefaultServings(String(data.defaultServings));
+      setSites(data.allowedRecipeSites);
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div className="page"><p>Loading settings...</p></div>;
+
+  return (
+    <div className="page">
+      <h1>Settings</h1>
+
+      {error && <div className="error">{error}</div>}
+
+      <div className="settings-section">
+        <h2>General</h2>
+        <label>
+          Timezone
+          <input type="text" value={timezone} onChange={e => { setTimezone(e.target.value); setSaved(false); }} />
+        </label>
+        <label>
+          Default Servings
+          <input
+            type="number"
+            value={defaultServings}
+            onChange={e => { setDefaultServings(e.target.value); setSaved(false); }}
+            min={1}
+          />
+        </label>
+      </div>
+
+      <div className="settings-section">
+        <h2>Internet Recipe Search Sites</h2>
+        <p className="muted">These sites are searched when looking for recipes online in the Global Recipe Book.</p>
+
+        {sites.length > 0 ? (
+          <ul className="site-list">
+            {sites.map(site => (
+              <li key={site} className="site-item">
+                <span>{site}</span>
+                <button type="button" onClick={() => removeSite(site)} className="btn btn-danger btn-small">X</button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="muted" style={{ marginBottom: '0.75rem' }}>No sites configured. Web search is disabled.</p>
+        )}
+
+        <div className="add-site-row">
+          <input
+            type="text"
+            placeholder="e.g. myrecipes.com"
+            value={newSite}
+            onChange={e => setNewSite(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSite(); } }}
+          />
+          <button type="button" onClick={addSite} className="btn btn-small">Add</button>
+        </div>
+
+        {missingSuggestions.length > 0 && (
+          <div className="site-suggestions">
+            <span className="muted" style={{ fontSize: '0.85rem' }}>Suggestions:</span>
+            {missingSuggestions.map(s => (
+              <button key={s} type="button" onClick={() => addSuggestion(s)} className="site-chip">{s}</button>
+            ))}
+          </div>
+        )}
+
+        {sites.length === 0 && (
+          <button type="button" onClick={resetToDefaults} className="btn" style={{ marginTop: '0.5rem' }}>
+            Reset to Defaults
+          </button>
+        )}
+      </div>
+
+      <div className="btn-group" style={{ marginTop: '1.5rem' }}>
+        <button type="button" onClick={handleSave} className="btn btn-primary" disabled={saving}>
+          {saving ? 'Saving...' : 'Save Settings'}
+        </button>
+        {saved && <span style={{ padding: '0.5rem', color: 'var(--primary)', fontWeight: 500 }}>Saved!</span>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -168,6 +168,25 @@ body {
 .ingredient-row input[type="number"] { flex: 1; }
 .ingredient-row select:last-of-type { flex: 1; }
 
+/* Ingredient Autocomplete */
+.autocomplete-wrap { position: relative; flex: 2; }
+.autocomplete-wrap input { width: 100%; }
+.autocomplete-dropdown {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 50;
+  background: var(--surface); border: 1px solid var(--border); border-top: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+  max-height: 264px; overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+.autocomplete-option {
+  padding: 0.5rem 0.75rem; cursor: pointer; font-size: 0.875rem;
+  min-height: 44px; display: flex; align-items: center;
+}
+.autocomplete-option:hover, .autocomplete-option.highlighted { background: var(--bg); }
+.autocomplete-loading, .autocomplete-empty {
+  padding: 0.5rem 0.75rem; color: var(--muted); font-size: 0.85rem;
+}
+
 .instructions { white-space: pre-wrap; }
 .muted { color: var(--muted); font-size: 0.875rem; }
 .empty { color: var(--muted); text-align: center; padding: 3rem; }
@@ -369,6 +388,31 @@ body {
   .week-grid { grid-template-columns: 1fr; }
   .month-view { display: none; }
 }
+
+/* Settings Page */
+.settings-section { margin-bottom: 2rem; }
+.settings-section h2 { font-size: 1.125rem; margin-bottom: 0.75rem; }
+.settings-section label {
+  display: flex; flex-direction: column; gap: 0.25rem;
+  font-weight: 500; font-size: 0.875rem; margin-bottom: 0.75rem;
+}
+.settings-section input, .settings-section select {
+  padding: 0.5rem 0.75rem; border: 1px solid var(--border);
+  border-radius: var(--radius); font-size: 0.875rem;
+}
+.site-list { list-style: none; margin-bottom: 0.75rem; }
+.site-item {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0.4rem 0.75rem; border-bottom: 1px solid var(--border); font-size: 0.875rem;
+}
+.add-site-row { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; }
+.add-site-row input { flex: 1; }
+.site-suggestions { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+.site-chip {
+  background: var(--bg); border: 1px solid var(--border); border-radius: 999px;
+  padding: 0.2rem 0.6rem; font-size: 0.8rem; cursor: pointer; color: var(--primary);
+}
+.site-chip:hover { background: #eff6ff; border-color: var(--primary); }
 
 /* Product variant dropdown */
 .variant-select {

--- a/src/main/java/com/endoran/foodplan/controller/GlobalRecipeController.java
+++ b/src/main/java/com/endoran/foodplan/controller/GlobalRecipeController.java
@@ -6,6 +6,7 @@ import com.endoran.foodplan.dto.RecipeResponse;
 import com.endoran.foodplan.dto.SharedRecipeResponse;
 import com.endoran.foodplan.dto.WebRecipeSearchResult;
 import com.endoran.foodplan.service.GlobalRecipeService;
+import com.endoran.foodplan.service.OrgSettingsService;
 import com.endoran.foodplan.service.RecipeNotFoundException;
 import com.endoran.foodplan.service.WebRecipeSearchService;
 import org.springframework.http.HttpStatus;
@@ -23,11 +24,14 @@ public class GlobalRecipeController {
 
     private final GlobalRecipeService globalRecipeService;
     private final WebRecipeSearchService webRecipeSearchService;
+    private final OrgSettingsService orgSettingsService;
 
     public GlobalRecipeController(GlobalRecipeService globalRecipeService,
-                                  WebRecipeSearchService webRecipeSearchService) {
+                                  WebRecipeSearchService webRecipeSearchService,
+                                  OrgSettingsService orgSettingsService) {
         this.globalRecipeService = globalRecipeService;
         this.webRecipeSearchService = webRecipeSearchService;
+        this.orgSettingsService = orgSettingsService;
     }
 
     @GetMapping("/status")
@@ -73,12 +77,15 @@ public class GlobalRecipeController {
 
     @GetMapping("/web-search")
     public ResponseEntity<List<WebRecipeSearchResult>> webSearch(
+            @AuthenticationPrincipal Jwt jwt,
             @RequestParam("q") String query) {
         checkEnabled();
         if (query == null || query.isBlank() || query.length() < 2) {
             return ResponseEntity.ok(List.of());
         }
-        return ResponseEntity.ok(webRecipeSearchService.search(query));
+        String orgId = jwt.getClaimAsString("orgId");
+        List<String> sites = orgSettingsService.getAllowedRecipeSites(orgId);
+        return ResponseEntity.ok(webRecipeSearchService.search(query, sites));
     }
 
     @GetMapping("/{sharedId}")

--- a/src/main/java/com/endoran/foodplan/controller/OrgSettingsController.java
+++ b/src/main/java/com/endoran/foodplan/controller/OrgSettingsController.java
@@ -1,0 +1,34 @@
+package com.endoran.foodplan.controller;
+
+import com.endoran.foodplan.dto.OrgSettingsResponse;
+import com.endoran.foodplan.dto.UpdateOrgSettingsRequest;
+import com.endoran.foodplan.service.OrgSettingsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/settings")
+public class OrgSettingsController {
+
+    private final OrgSettingsService orgSettingsService;
+
+    public OrgSettingsController(OrgSettingsService orgSettingsService) {
+        this.orgSettingsService = orgSettingsService;
+    }
+
+    @GetMapping
+    public ResponseEntity<OrgSettingsResponse> getSettings(@AuthenticationPrincipal Jwt jwt) {
+        String orgId = jwt.getClaimAsString("orgId");
+        return ResponseEntity.ok(orgSettingsService.getSettings(orgId));
+    }
+
+    @PutMapping
+    public ResponseEntity<OrgSettingsResponse> updateSettings(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody UpdateOrgSettingsRequest request) {
+        String orgId = jwt.getClaimAsString("orgId");
+        return ResponseEntity.ok(orgSettingsService.updateSettings(orgId, request));
+    }
+}

--- a/src/main/java/com/endoran/foodplan/dto/OrgSettingsResponse.java
+++ b/src/main/java/com/endoran/foodplan/dto/OrgSettingsResponse.java
@@ -1,0 +1,10 @@
+package com.endoran.foodplan.dto;
+
+import java.util.List;
+
+public record OrgSettingsResponse(
+        String timezone,
+        int defaultServings,
+        List<String> allowedRecipeSites,
+        List<String> defaultRecipeSites
+) {}

--- a/src/main/java/com/endoran/foodplan/dto/UpdateOrgSettingsRequest.java
+++ b/src/main/java/com/endoran/foodplan/dto/UpdateOrgSettingsRequest.java
@@ -1,0 +1,9 @@
+package com.endoran.foodplan.dto;
+
+import java.util.List;
+
+public record UpdateOrgSettingsRequest(
+        String timezone,
+        Integer defaultServings,
+        List<String> allowedRecipeSites
+) {}

--- a/src/main/java/com/endoran/foodplan/model/OrgSettings.java
+++ b/src/main/java/com/endoran/foodplan/model/OrgSettings.java
@@ -1,20 +1,36 @@
 package com.endoran.foodplan.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class OrgSettings {
 
+    public static final List<String> DEFAULT_RECIPE_SITES = List.of(
+            "allrecipes.com", "food.com", "foodnetwork.com",
+            "simplyrecipes.com", "budgetbytes.com", "seriouseats.com",
+            "epicurious.com", "bonappetit.com", "delish.com",
+            "tasty.co", "cookieandkate.com", "minimalistbaker.com"
+    );
+
     private String timezone;
     private int defaultServings;
+    private List<String> allowedRecipeSites;
 
     public OrgSettings() {
         this.timezone = "America/Chicago";
         this.defaultServings = 4;
+        this.allowedRecipeSites = new ArrayList<>(DEFAULT_RECIPE_SITES);
     }
 
     public OrgSettings(String timezone, int defaultServings) {
+        this(timezone, defaultServings, null);
+    }
+
+    public OrgSettings(String timezone, int defaultServings, List<String> allowedRecipeSites) {
         this.timezone = timezone;
         this.defaultServings = defaultServings;
+        this.allowedRecipeSites = allowedRecipeSites != null ? new ArrayList<>(allowedRecipeSites) : new ArrayList<>(DEFAULT_RECIPE_SITES);
     }
 
     public String getTimezone() {
@@ -33,16 +49,26 @@ public class OrgSettings {
         this.defaultServings = defaultServings;
     }
 
+    public List<String> getAllowedRecipeSites() {
+        return allowedRecipeSites;
+    }
+
+    public void setAllowedRecipeSites(List<String> allowedRecipeSites) {
+        this.allowedRecipeSites = allowedRecipeSites;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OrgSettings that = (OrgSettings) o;
-        return defaultServings == that.defaultServings && Objects.equals(timezone, that.timezone);
+        return defaultServings == that.defaultServings
+                && Objects.equals(timezone, that.timezone)
+                && Objects.equals(allowedRecipeSites, that.allowedRecipeSites);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(timezone, defaultServings);
+        return Objects.hash(timezone, defaultServings, allowedRecipeSites);
     }
 }

--- a/src/main/java/com/endoran/foodplan/service/OrgSettingsService.java
+++ b/src/main/java/com/endoran/foodplan/service/OrgSettingsService.java
@@ -1,0 +1,72 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.dto.OrgSettingsResponse;
+import com.endoran.foodplan.dto.UpdateOrgSettingsRequest;
+import com.endoran.foodplan.model.Organization;
+import com.endoran.foodplan.model.OrgSettings;
+import com.endoran.foodplan.repository.OrganizationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class OrgSettingsService {
+
+    private final OrganizationRepository organizationRepository;
+
+    public OrgSettingsService(OrganizationRepository organizationRepository) {
+        this.organizationRepository = organizationRepository;
+    }
+
+    public OrgSettingsResponse getSettings(String orgId) {
+        Organization org = organizationRepository.findById(orgId)
+                .orElseThrow(() -> new IllegalArgumentException("Organization not found"));
+        OrgSettings settings = org.getSettings();
+        if (settings == null) {
+            settings = new OrgSettings();
+        }
+        List<String> sites = settings.getAllowedRecipeSites();
+        if (sites == null) {
+            sites = OrgSettings.DEFAULT_RECIPE_SITES;
+        }
+        return new OrgSettingsResponse(
+                settings.getTimezone(),
+                settings.getDefaultServings(),
+                sites,
+                OrgSettings.DEFAULT_RECIPE_SITES
+        );
+    }
+
+    public OrgSettingsResponse updateSettings(String orgId, UpdateOrgSettingsRequest request) {
+        Organization org = organizationRepository.findById(orgId)
+                .orElseThrow(() -> new IllegalArgumentException("Organization not found"));
+        OrgSettings settings = org.getSettings();
+        if (settings == null) {
+            settings = new OrgSettings();
+            org.setSettings(settings);
+        }
+        if (request.timezone() != null) {
+            settings.setTimezone(request.timezone());
+        }
+        if (request.defaultServings() != null) {
+            settings.setDefaultServings(request.defaultServings());
+        }
+        if (request.allowedRecipeSites() != null) {
+            settings.setAllowedRecipeSites(request.allowedRecipeSites());
+        }
+        organizationRepository.save(org);
+        return getSettings(orgId);
+    }
+
+    public List<String> getAllowedRecipeSites(String orgId) {
+        Organization org = organizationRepository.findById(orgId).orElse(null);
+        if (org == null || org.getSettings() == null) {
+            return OrgSettings.DEFAULT_RECIPE_SITES;
+        }
+        List<String> sites = org.getSettings().getAllowedRecipeSites();
+        if (sites == null) {
+            return OrgSettings.DEFAULT_RECIPE_SITES;
+        }
+        return sites;
+    }
+}

--- a/src/main/java/com/endoran/foodplan/service/WebRecipeSearchService.java
+++ b/src/main/java/com/endoran/foodplan/service/WebRecipeSearchService.java
@@ -27,13 +27,6 @@ public class WebRecipeSearchService {
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
 
-    private static final List<String> RECIPE_SITES = List.of(
-            "allrecipes.com", "food.com", "foodnetwork.com",
-            "simplyrecipes.com", "budgetbytes.com", "seriouseats.com",
-            "epicurious.com", "bonappetit.com", "delish.com",
-            "tasty.co", "cookieandkate.com", "minimalistbaker.com"
-    );
-
     // DuckDuckGo HTML result patterns
     private static final Pattern RESULT_PATTERN = Pattern.compile(
             "<a[^>]+class=\"result__a\"[^>]+href=\"([^\"]+)\"[^>]*>(.+?)</a>",
@@ -43,8 +36,11 @@ public class WebRecipeSearchService {
             Pattern.DOTALL);
     private static final Pattern HTML_TAG = Pattern.compile("<[^>]+>");
 
-    public List<WebRecipeSearchResult> search(String query) {
-        String siteFilter = RECIPE_SITES.stream()
+    public List<WebRecipeSearchResult> search(String query, List<String> allowedSites) {
+        if (allowedSites == null || allowedSites.isEmpty()) {
+            return List.of();
+        }
+        String siteFilter = allowedSites.stream()
                 .map(s -> "site:" + s)
                 .reduce((a, b) -> a + " OR " + b)
                 .orElse("");


### PR DESCRIPTION
## Summary
- **Live ingredient search**: Ingredient list page now filters live with 300ms debounce instead of form-submit. Recipe form ingredient picker replaced with autocomplete (keyboard nav, mobile-friendly 44px touch targets, blur-race fix).
- **Configurable recipe search sites**: New `allowedRecipeSites` field on OrgSettings with 12 boilerplate defaults. New Settings page lets users add/remove sites, see suggestions for missing defaults, and reset. WebRecipeSearchService now accepts the org's site list instead of using hardcoded values.

## Changes
- **Backend**: OrgSettings model + DTOs + OrgSettingsService + OrgSettingsController (GET/PUT /api/v1/settings), WebRecipeSearchService parameterized, GlobalRecipeController wired up
- **Frontend**: settings API client, IngredientListPage live search, RecipeFormPage autocomplete, SettingsPage, routing + nav link, autocomplete + settings CSS

## Test plan
- [ ] Settings page: load, add/remove sites, save, reload — persists
- [ ] Remove all sites → web search returns no results
- [ ] Ingredient list: type in search — results filter live with debounce
- [ ] Recipe form: type ingredient name — autocomplete appears, arrow keys + Enter work
- [ ] Recipe form: type unknown ingredient, save — backend auto-creates
- [ ] Mobile: autocomplete touch targets are usable
- [ ] Existing orgs without `allowedRecipeSites` field get defaults on load