### PR TITLE
#269 Sort ingredients alphabetically (case-insensitive)

### DIFF
--- a/src/main/java/com/endoran/foodplan/service/IngredientService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientService.java
@@ -13,6 +13,7 @@ import com.endoran.foodplan.repository.IngredientRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -54,6 +55,7 @@ public class IngredientService {
         } else {
             ingredients = ingredientRepository.findByOrgId(orgId);
         }
+        ingredients.sort(Comparator.comparing(Ingredient::getName, String.CASE_INSENSITIVE_ORDER));
         return ingredients.stream().map(this::toResponse).toList();
     }
 
@@ -136,6 +138,7 @@ public class IngredientService {
                 })
                 .toList();
         ingredientRepository.saveAll(updated);
+        ingredients.sort(Comparator.comparing(Ingredient::getName, String.CASE_INSENSITIVE_ORDER));
         return ingredients.stream().map(this::toResponse).toList();
     }
 


### PR DESCRIPTION
## Summary
- Adds case-insensitive alphabetical sorting to ingredient list endpoint and auto-categorize results
- Single `Comparator.comparing(Ingredient::getName, String.CASE_INSENSITIVE_ORDER)` in the service layer, so all consumers (ingredient list page, autocomplete dropdown) get sorted results

## Test plan
- [ ] Ingredient list page: ingredients display A-Z regardless of original insert order
- [ ] Search results: filtered results are also sorted
- [ ] Autocomplete in recipe form: suggestions appear sorted
- [ ] Mixed case (e.g., "butter" vs "Brown Sugar") sorts correctly