### PR TITLE
#264 Fix servings field clearing on iOS

### DIFF
--- a/frontend/src/calendar/ServingsModal.tsx
+++ b/frontend/src/calendar/ServingsModal.tsx
@@ -10,13 +10,14 @@ interface ServingsModalProps {
 const MEAL_TYPES: MealType[] = ['BREAKFAST', 'LUNCH', 'DINNER', 'SNACK'];
 
 export function ServingsModal({ recipeName, onConfirm, onCancel }: ServingsModalProps) {
-  const [servings, setServings] = useState(2);
+  const [servingsText, setServingsText] = useState('2');
   const [mealType, setMealType] = useState<MealType>('DINNER');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (servings >= 1) {
-      onConfirm(servings, mealType);
+    const n = parseInt(servingsText);
+    if (!isNaN(n) && n >= 1) {
+      onConfirm(n, mealType);
     }
   };
 
@@ -38,8 +39,8 @@ export function ServingsModal({ recipeName, onConfirm, onCancel }: ServingsModal
             <input
               type="number"
               min={1}
-              value={servings}
-              onChange={e => setServings(parseInt(e.target.value) || 1)}
+              value={servingsText}
+              onChange={e => setServingsText(e.target.value)}
             />
           </label>
           <div className="btn-group">

--- a/frontend/src/recipes/RecipeFormPage.tsx
+++ b/frontend/src/recipes/RecipeFormPage.tsx
@@ -120,7 +120,7 @@ export function RecipeFormPage() {
 
   const [name, setName] = useState('');
   const [instructions, setInstructions] = useState('');
-  const [baseServings, setBaseServings] = useState(1);
+  const [baseServingsText, setBaseServingsText] = useState('1');
   const [ingredients, setIngredients] = useState<IngredientRow[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -133,7 +133,7 @@ export function RecipeFormPage() {
     const recipe = await apiGet<Recipe>(`/api/v1/recipes/${id}`);
     setName(recipe.name);
     setInstructions(recipe.instructions || '');
-    setBaseServings(recipe.baseServings);
+    setBaseServingsText(String(recipe.baseServings));
     setIngredients(recipe.ingredients.map(ing => ({
       section: ing.section || '',
       ingredientId: ing.ingredientId,
@@ -161,6 +161,13 @@ export function RecipeFormPage() {
     e.preventDefault();
     setError('');
     setLoading(true);
+
+    const baseServings = parseInt(baseServingsText);
+    if (isNaN(baseServings) || baseServings < 1) {
+      setError('Base servings must be at least 1');
+      setLoading(false);
+      return;
+    }
 
     const body = {
       name,
@@ -217,7 +224,7 @@ export function RecipeFormPage() {
 
         <label>
           Base Servings
-          <input type="number" value={baseServings} onChange={e => setBaseServings(parseInt(e.target.value) || 1)} min={1} />
+          <input type="number" value={baseServingsText} onChange={e => setBaseServingsText(e.target.value)} min={1} />
         </label>
 
         <div className="section">

--- a/frontend/src/recipes/RecipeImportPage.tsx
+++ b/frontend/src/recipes/RecipeImportPage.tsx
@@ -41,7 +41,7 @@ export function RecipeImportPage() {
 
   const [name, setName] = useState('');
   const [instructions, setInstructions] = useState('');
-  const [baseServings, setBaseServings] = useState(1);
+  const [baseServingsText, setBaseServingsText] = useState('1');
   const [ingredients, setIngredients] = useState<ImportedIngredient[]>([]);
   const [saving, setSaving] = useState(false);
 
@@ -59,7 +59,7 @@ export function RecipeImportPage() {
       setPreview(data);
       setName(data.name);
       setInstructions(data.instructions);
-      setBaseServings(data.baseServings);
+      setBaseServingsText(String(data.baseServings));
       setIngredients(data.ingredients);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Import failed');
@@ -101,6 +101,12 @@ export function RecipeImportPage() {
   };
 
   const saveRecipe = async () => {
+    const baseServings = parseInt(baseServingsText);
+    if (isNaN(baseServings) || baseServings < 1) {
+      setError('Base servings must be at least 1');
+      return;
+    }
+
     const body = {
       name,
       instructions: instructions || null,
@@ -179,8 +185,8 @@ export function RecipeImportPage() {
             Base Servings
             <input
               type="number"
-              value={baseServings}
-              onChange={e => setBaseServings(parseInt(e.target.value) || 1)}
+              value={baseServingsText}
+              onChange={e => setBaseServingsText(e.target.value)}
               min={1}
             />
           </label>

--- a/frontend/src/recipes/RecipeScanPage.tsx
+++ b/frontend/src/recipes/RecipeScanPage.tsx
@@ -52,7 +52,7 @@ export function RecipeScanPage() {
   // Edit state for selected recipe
   const [name, setName] = useState('');
   const [instructions, setInstructions] = useState('');
-  const [baseServings, setBaseServings] = useState(1);
+  const [baseServingsText, setBaseServingsText] = useState('1');
   const [ingredients, setIngredients] = useState<ImportedIngredient[]>([]);
   const [saving, setSaving] = useState(false);
 
@@ -64,7 +64,7 @@ export function RecipeScanPage() {
     setSelectedIndex(index);
     setName(recipe.name);
     setInstructions(recipe.instructions);
-    setBaseServings(recipe.baseServings);
+    setBaseServingsText(String(recipe.baseServings));
     setIngredients(recipe.ingredients);
     setStep('edit');
   };
@@ -146,6 +146,12 @@ export function RecipeScanPage() {
   };
 
   const saveRecipe = async () => {
+    const baseServings = parseInt(baseServingsText);
+    if (isNaN(baseServings) || baseServings < 1) {
+      setError('Base servings must be at least 1');
+      return;
+    }
+
     const body: Record<string, unknown> = {
       name,
       instructions: instructions || null,
@@ -291,8 +297,8 @@ export function RecipeScanPage() {
             Base Servings
             <input
               type="number"
-              value={baseServings}
-              onChange={e => setBaseServings(parseInt(e.target.value) || 1)}
+              value={baseServingsText}
+              onChange={e => setBaseServingsText(e.target.value)}
               min={1}
             />
           </label>


### PR DESCRIPTION
## Summary
- On iOS, clearing a number input (backspace to empty) causes `parseInt('')` to return `NaN`, which the `|| 1` fallback immediately replaces with `1` — making it impossible to type a new value
- Fix: store servings as a text string, validate on submit instead of on every keystroke
- Applied to all 4 pages with servings inputs: RecipeFormPage, RecipeImportPage, RecipeScanPage, ServingsModal

## Test plan
- [ ] iOS Safari: clear servings field, type new number — field stays empty until user types
- [ ] Submit with empty/invalid servings — shows validation error
- [ ] Submit with valid servings — saves correctly
- [ ] Desktop: same behavior, no regressions
- [ ] Edit existing recipe: servings field populates correctly