### PR TITLE
#264 Add validation feedback to ServingsModal

### DIFF
--- a/frontend/src/calendar/ServingsModal.tsx
+++ b/frontend/src/calendar/ServingsModal.tsx
@@ -12,19 +12,23 @@ const MEAL_TYPES: MealType[] = ['BREAKFAST', 'LUNCH', 'DINNER', 'SNACK'];
 export function ServingsModal({ recipeName, onConfirm, onCancel }: ServingsModalProps) {
   const [servingsText, setServingsText] = useState('2');
   const [mealType, setMealType] = useState<MealType>('DINNER');
+  const [error, setError] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const n = parseInt(servingsText);
-    if (!isNaN(n) && n >= 1) {
-      onConfirm(n, mealType);
+    if (isNaN(n) || n < 1) {
+      setError('Servings must be at least 1');
+      return;
     }
+    onConfirm(n, mealType);
   };
 
   return (
     <div className="modal-backdrop" onClick={onCancel}>
       <div className="modal" onClick={e => e.stopPropagation()}>
         <h3>Add "{recipeName}"</h3>
+        {error && <div className="error">{error}</div>}
         <form onSubmit={handleSubmit} className="modal-form">
           <label>
             Meal


### PR DESCRIPTION
## Summary
- ServingsModal silently swallowed invalid servings input (empty/0/negative) — no error shown to user
- Now shows error message consistent with RecipeFormPage, RecipeImportPage, RecipeScanPage
- Found during self-review of #264 fix

## Test plan
- [ ] Open calendar, drag recipe to day → modal appears
- [ ] Clear servings field, click Add → shows "Servings must be at least 1"
- [ ] Type valid number, click Add → works normally