### PR TITLE
Ingredient name enrichment: normalization, alias resolution, dedup

### DIFF
--- a/frontend/src/recipes/IngredientListPage.tsx
+++ b/frontend/src/recipes/IngredientListPage.tsx
@@ -1,14 +1,23 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { apiGet, apiDelete } from '../api/client';
+import { apiGet, apiDelete, apiPost } from '../api/client';
 import { formatEnum } from '../utils/formatEnum';
 import type { Ingredient } from './types';
+
+interface NormalizationResult {
+  renames: { ingredientId: string; oldName: string; newName: string }[];
+  merges: { winnerId: string; winnerName: string; loserId: string; loserName: string; canonicalName: string }[];
+  skipped: number;
+}
 
 export function IngredientListPage() {
   const [ingredients, setIngredients] = useState<Ingredient[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [normalizing, setNormalizing] = useState(false);
+  const [normalizePreview, setNormalizePreview] = useState<NormalizationResult | null>(null);
+  const [normalizeError, setNormalizeError] = useState('');
 
   const load = async (name?: string) => {
     setLoading(true);
@@ -36,11 +45,45 @@ export function IngredientListPage() {
     load(search || undefined);
   };
 
+  const handleNormalizePreview = async () => {
+    setNormalizeError('');
+    setNormalizing(true);
+    try {
+      const result = await apiPost<NormalizationResult>('/api/v1/ingredients/normalize?dryRun=true', {});
+      setNormalizePreview(result);
+    } catch (err) {
+      setNormalizeError(err instanceof Error ? err.message : 'Normalization preview failed');
+    } finally {
+      setNormalizing(false);
+    }
+  };
+
+  const handleNormalizeConfirm = async () => {
+    setNormalizeError('');
+    setNormalizing(true);
+    try {
+      await apiPost<NormalizationResult>('/api/v1/ingredients/normalize?dryRun=false', {});
+      setNormalizePreview(null);
+      load(search || undefined);
+    } catch (err) {
+      setNormalizeError(err instanceof Error ? err.message : 'Normalization failed');
+    } finally {
+      setNormalizing(false);
+    }
+  };
+
   return (
     <div className="page">
       <div className="page-header">
         <h1>Ingredients</h1>
         <div className="btn-group">
+          <button
+            className="btn"
+            onClick={handleNormalizePreview}
+            disabled={normalizing}
+          >
+            {normalizing ? 'Checking...' : 'Normalize Names'}
+          </button>
           <Link to="/ingredients/bulk-edit" className="btn">Bulk Edit</Link>
           <Link to="/ingredients/new" className="btn btn-primary">New Ingredient</Link>
         </div>
@@ -54,6 +97,48 @@ export function IngredientListPage() {
           onChange={e => handleSearchChange(e.target.value)}
         />
       </div>
+
+      {normalizeError && <div className="error">{normalizeError}</div>}
+
+      {normalizePreview && (
+        <div className="normalize-preview">
+          <h3>Normalization Preview</h3>
+          {normalizePreview.renames.length === 0 && normalizePreview.merges.length === 0 ? (
+            <p className="muted">All ingredient names are already normalized.</p>
+          ) : (
+            <>
+              {normalizePreview.renames.length > 0 && (
+                <div>
+                  <h4>Renames ({normalizePreview.renames.length})</h4>
+                  <ul>
+                    {normalizePreview.renames.map(r => (
+                      <li key={r.ingredientId}>{r.oldName} &rarr; {r.newName}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {normalizePreview.merges.length > 0 && (
+                <div>
+                  <h4>Merges ({normalizePreview.merges.length})</h4>
+                  <ul>
+                    {normalizePreview.merges.map(m => (
+                      <li key={m.loserId}>
+                        "{m.loserName}" will merge into "{m.winnerName}" &rarr; {m.canonicalName}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <div className="btn-group" style={{ marginTop: '0.75rem' }}>
+                <button className="btn btn-primary" onClick={handleNormalizeConfirm} disabled={normalizing}>
+                  {normalizing ? 'Normalizing...' : 'Apply Changes'}
+                </button>
+                <button className="btn" onClick={() => setNormalizePreview(null)}>Cancel</button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
 
       {loading ? (
         <p>Loading...</p>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -209,6 +209,15 @@ body {
   background: #fef3c7; color: #92400e; text-transform: uppercase;
 }
 
+.normalize-preview {
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 1rem; margin-bottom: 1rem;
+}
+.normalize-preview h3 { margin: 0 0 0.75rem; font-size: 1rem; }
+.normalize-preview h4 { margin: 0.75rem 0 0.25rem; font-size: 0.9rem; color: #666; }
+.normalize-preview ul { margin: 0; padding-left: 1.25rem; }
+.normalize-preview li { font-size: 0.9rem; line-height: 1.6; }
+
 /* Calendar Layout */
 .calendar-page { display: flex; flex-direction: column; gap: 1rem; }
 .calendar-nav { display: flex; align-items: center; gap: 0.5rem; }

--- a/src/main/java/com/endoran/foodplan/controller/IngredientController.java
+++ b/src/main/java/com/endoran/foodplan/controller/IngredientController.java
@@ -10,6 +10,7 @@ import com.endoran.foodplan.dto.UpdateIngredientRequest;
 import com.endoran.foodplan.model.DietaryTag;
 import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.service.IngredientNotFoundException;
+import com.endoran.foodplan.service.IngredientNormalizationService;
 import com.endoran.foodplan.service.IngredientService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -35,9 +36,12 @@ import java.util.Map;
 public class IngredientController {
 
     private final IngredientService ingredientService;
+    private final IngredientNormalizationService normalizationService;
 
-    public IngredientController(IngredientService ingredientService) {
+    public IngredientController(IngredientService ingredientService,
+                                IngredientNormalizationService normalizationService) {
         this.ingredientService = ingredientService;
+        this.normalizationService = normalizationService;
     }
 
     @PostMapping
@@ -97,6 +101,14 @@ public class IngredientController {
             @AuthenticationPrincipal Jwt jwt) {
         String orgId = jwt.getClaimAsString("orgId");
         return ResponseEntity.ok(ingredientService.autoCategorize(orgId));
+    }
+
+    @PostMapping("/normalize")
+    public ResponseEntity<IngredientNormalizationService.NormalizationResult> normalize(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(defaultValue = "true") boolean dryRun) {
+        String orgId = jwt.getClaimAsString("orgId");
+        return ResponseEntity.ok(normalizationService.normalizeAll(orgId, dryRun));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/endoran/foodplan/service/GlobalRecipeService.java
+++ b/src/main/java/com/endoran/foodplan/service/GlobalRecipeService.java
@@ -319,6 +319,7 @@ public class GlobalRecipeService {
                                        Map<String, SharedRecipeIngredient> sourceMetadata) {
         for (var ri : ingredients) {
             if (ri.getIngredientId() != null && !ri.getIngredientId().isBlank()) continue;
+            ri.setIngredientName(IngredientAliasDictionary.resolveAndNormalize(ri.getIngredientName()));
             var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, ri.getIngredientName());
             if (existing.isPresent()) {
                 ri.setIngredientId(existing.get().getId());

--- a/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
@@ -20,8 +20,10 @@ public final class IngredientAliasDictionary {
         alias(m, "Whole Milk", "milk", "whole milk");
         alias(m, "Cheddar Cheese", "cheddar", "sharp cheddar", "mild cheddar");
         alias(m, "Mozzarella Cheese", "mozzarella", "fresh mozzarella", "shredded mozzarella");
-        alias(m, "Monterey Jack Cheese", "monterey jack", "pepper jack", "pepper jack cheese");
-        alias(m, "Swiss Cheese", "swiss", "gruyere", "gruyère");
+        alias(m, "Monterey Jack Cheese", "monterey jack");
+        alias(m, "Pepper Jack Cheese", "pepper jack");
+        alias(m, "Swiss Cheese", "swiss");
+        alias(m, "Gruyere Cheese", "gruyere", "gruyère");
         alias(m, "Ricotta Cheese", "ricotta");
         alias(m, "Cottage Cheese", "cottage cheese");
         alias(m, "Plain Yogurt", "yogurt", "plain greek yogurt", "greek yogurt");

--- a/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
@@ -1,0 +1,204 @@
+package com.endoran.foodplan.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class IngredientAliasDictionary {
+
+    private static final Map<String, String> ALIASES;
+
+    static {
+        Map<String, String> m = new HashMap<>();
+
+        // --- Dairy ---
+        alias(m, "Parmesan Cheese", "parmigiano-reggiano", "parmigiano reggiano", "parmesan",
+                "parm cheese", "grated parmesan", "shredded parmesan");
+        alias(m, "Heavy Cream", "heavy whipping cream", "whipping cream");
+        alias(m, "Cream Cheese", "cream cheese spread", "neufchatel");
+        alias(m, "Sour Cream", "soured cream");
+        alias(m, "Butter", "unsalted butter", "salted butter", "sweet cream butter");
+        alias(m, "Whole Milk", "milk", "whole milk");
+        alias(m, "Cheddar Cheese", "cheddar", "sharp cheddar", "mild cheddar");
+        alias(m, "Mozzarella Cheese", "mozzarella", "fresh mozzarella", "shredded mozzarella");
+        alias(m, "Monterey Jack Cheese", "monterey jack", "pepper jack", "pepper jack cheese");
+        alias(m, "Swiss Cheese", "swiss", "gruyere", "gruyère");
+        alias(m, "Ricotta Cheese", "ricotta");
+        alias(m, "Cottage Cheese", "cottage cheese");
+        alias(m, "Plain Yogurt", "yogurt", "plain greek yogurt", "greek yogurt");
+        alias(m, "Eggs", "egg", "large egg", "large eggs", "whole egg", "whole eggs");
+        alias(m, "Half and Half", "half & half", "half-and-half");
+
+        // --- Proteins ---
+        alias(m, "Ground Beef", "hamburger meat", "ground chuck", "lean ground beef",
+                "hamburger", "minced beef", "beef mince");
+        alias(m, "Chicken Breast", "boneless skinless chicken breast", "boneless chicken breast",
+                "skinless chicken breast", "chicken breasts");
+        alias(m, "Chicken Thighs", "boneless skinless chicken thighs", "boneless chicken thighs",
+                "chicken thigh");
+        alias(m, "Whole Chicken", "roasting chicken", "whole fryer");
+        alias(m, "Bacon", "bacon strips", "sliced bacon", "thick cut bacon");
+        alias(m, "Italian Sausage", "italian sausage links", "sweet italian sausage",
+                "hot italian sausage", "mild italian sausage");
+        alias(m, "Ground Turkey", "lean ground turkey", "turkey mince");
+        alias(m, "Ground Pork", "pork mince");
+        alias(m, "Pork Chops", "pork chop", "bone-in pork chops", "boneless pork chops");
+        alias(m, "Salmon Fillet", "salmon", "salmon filet", "fresh salmon");
+        alias(m, "Shrimp", "prawns", "raw shrimp", "large shrimp", "jumbo shrimp");
+        alias(m, "Tofu", "firm tofu", "extra firm tofu");
+
+        // --- Produce ---
+        alias(m, "Green Onion", "scallion", "scallions", "spring onion", "spring onions",
+                "green onions");
+        alias(m, "Cilantro", "fresh cilantro", "coriander leaves", "fresh coriander");
+        alias(m, "Garlic", "fresh garlic", "garlic cloves", "garlic clove", "cloves garlic",
+                "clove garlic", "minced garlic");
+        alias(m, "Yellow Onion", "onion", "medium onion", "large onion", "onions",
+                "yellow onions", "cooking onion");
+        alias(m, "Red Onion", "red onions");
+        alias(m, "Bell Pepper", "green bell pepper", "red bell pepper", "bell peppers",
+                "green pepper", "red pepper");
+        alias(m, "Jalapeno", "jalapeño", "jalapeno pepper", "jalapeño pepper",
+                "jalapenos", "jalapeños");
+        alias(m, "Fresh Ginger", "ginger", "ginger root", "gingerroot");
+        alias(m, "Lemon", "lemons", "fresh lemon");
+        alias(m, "Lime", "limes", "fresh lime");
+        alias(m, "Roma Tomato", "roma tomatoes", "plum tomato", "plum tomatoes");
+        alias(m, "Cherry Tomatoes", "grape tomatoes", "cherry tomato");
+        alias(m, "Russet Potato", "potato", "potatoes", "russet potatoes", "baking potato");
+        alias(m, "Sweet Potato", "sweet potatoes", "yam", "yams");
+        alias(m, "Celery", "celery stalks", "celery stalk", "celery ribs");
+        alias(m, "Carrot", "carrots", "large carrot");
+        alias(m, "Broccoli", "broccoli florets", "broccoli crowns");
+        alias(m, "Spinach", "fresh spinach", "baby spinach");
+        alias(m, "Romaine Lettuce", "romaine", "romaine hearts");
+        alias(m, "Avocado", "avocados", "ripe avocado");
+        alias(m, "Mushrooms", "mushroom", "white mushrooms", "button mushrooms",
+                "cremini mushrooms", "baby bella mushrooms");
+        alias(m, "Corn", "sweet corn", "corn kernels", "corn on the cob");
+        alias(m, "Cabbage", "green cabbage", "head of cabbage");
+        alias(m, "Zucchini", "zucchini squash", "courgette");
+        alias(m, "Fresh Basil", "basil", "basil leaves", "sweet basil");
+        alias(m, "Fresh Parsley", "parsley", "flat leaf parsley", "italian parsley",
+                "flat-leaf parsley", "curly parsley");
+        alias(m, "Fresh Dill", "dill", "dill weed");
+        alias(m, "Fresh Thyme", "thyme", "thyme sprigs");
+        alias(m, "Fresh Rosemary", "rosemary", "rosemary sprigs");
+
+        // --- Spices & Seasonings ---
+        alias(m, "Garlic Powder", "granulated garlic", "dehydrated garlic");
+        alias(m, "Onion Powder", "dehydrated onion");
+        alias(m, "Chili Powder", "chile powder");
+        alias(m, "Ground Cumin", "cumin", "cumin powder");
+        alias(m, "Smoked Paprika", "pimenton");
+        alias(m, "Paprika", "sweet paprika", "hungarian paprika");
+        alias(m, "Ground Cinnamon", "cinnamon", "cinnamon powder");
+        alias(m, "Ground Nutmeg", "nutmeg", "nutmeg powder");
+        alias(m, "Cayenne Pepper", "cayenne", "ground cayenne", "ground red pepper");
+        alias(m, "Red Pepper Flakes", "crushed red pepper", "red chili flakes",
+                "crushed red pepper flakes");
+        alias(m, "Italian Seasoning", "italian herb blend", "italian herbs");
+        alias(m, "Bay Leaves", "bay leaf", "dried bay leaves");
+        alias(m, "Dried Oregano", "oregano");
+        alias(m, "Dried Basil", "basil flakes");
+        alias(m, "Ground Ginger", "ginger powder", "dried ginger");
+        alias(m, "Ground Turmeric", "turmeric", "turmeric powder");
+        alias(m, "Garam Masala", "garam masala powder");
+        alias(m, "Ground Black Pepper", "black pepper", "pepper", "ground pepper",
+                "freshly ground pepper", "freshly ground black pepper", "cracked black pepper");
+        // Note: salt variants are intentionally DISTINCT — do NOT alias across them
+        // kosher salt, sea salt, table salt, pink salt, ice cream salt are all different
+
+        // --- Pantry ---
+        alias(m, "All-Purpose Flour", "ap flour", "plain flour", "all purpose flour",
+                "flour", "white flour", "unbleached flour");
+        alias(m, "Bread Flour", "strong flour", "high gluten flour");
+        alias(m, "Granulated Sugar", "sugar", "white sugar", "cane sugar");
+        alias(m, "Brown Sugar", "light brown sugar", "dark brown sugar", "packed brown sugar");
+        alias(m, "Powdered Sugar", "confectioners sugar", "confectioner's sugar",
+                "icing sugar", "10x sugar");
+        alias(m, "Baking Soda", "bicarbonate of soda", "bicarb");
+        alias(m, "Baking Powder", "double acting baking powder");
+        alias(m, "Vanilla Extract", "vanilla", "pure vanilla extract", "pure vanilla");
+        alias(m, "Cornstarch", "corn starch", "cornflour");
+        alias(m, "Panko Breadcrumbs", "panko", "panko bread crumbs");
+        alias(m, "Breadcrumbs", "bread crumbs", "dried breadcrumbs", "plain breadcrumbs");
+        alias(m, "White Rice", "rice", "long grain rice", "long-grain white rice");
+        alias(m, "Jasmine Rice", "jasmine");
+        alias(m, "Pasta", "dried pasta", "dry pasta");
+        alias(m, "Spaghetti", "spaghetti noodles", "spaghetti pasta");
+        alias(m, "Elbow Macaroni", "macaroni", "elbow pasta");
+        alias(m, "Penne", "penne pasta", "penne rigate");
+        alias(m, "Cocoa Powder", "unsweetened cocoa powder", "cocoa", "unsweetened cocoa");
+
+        // --- Oils & Condiments ---
+        alias(m, "Olive Oil", "extra virgin olive oil", "evoo", "extra-virgin olive oil",
+                "light olive oil");
+        alias(m, "Vegetable Oil", "canola oil", "neutral oil", "cooking oil");
+        alias(m, "Sesame Oil", "toasted sesame oil", "dark sesame oil");
+        alias(m, "Soy Sauce", "soya sauce", "shoyu", "tamari");
+        alias(m, "Worcestershire Sauce", "worcestershire", "lea & perrins");
+        alias(m, "Hot Sauce", "hot pepper sauce", "tabasco", "louisiana hot sauce");
+        alias(m, "Dijon Mustard", "dijon");
+        alias(m, "Yellow Mustard", "prepared mustard", "american mustard");
+        alias(m, "Ketchup", "catsup", "tomato ketchup");
+        alias(m, "Mayonnaise", "mayo");
+        alias(m, "Apple Cider Vinegar", "cider vinegar", "acv");
+        alias(m, "White Vinegar", "distilled white vinegar", "distilled vinegar");
+        alias(m, "Red Wine Vinegar", "red wine vin");
+        alias(m, "Rice Vinegar", "rice wine vinegar", "seasoned rice vinegar");
+        alias(m, "Honey", "raw honey", "pure honey");
+        alias(m, "Maple Syrup", "pure maple syrup");
+
+        // --- Canned ---
+        alias(m, "Diced Tomatoes", "canned diced tomatoes", "diced tomatoes (canned)",
+                "petite diced tomatoes");
+        alias(m, "Crushed Tomatoes", "canned crushed tomatoes");
+        alias(m, "Tomato Paste", "tomato paste (canned)");
+        alias(m, "Tomato Sauce", "canned tomato sauce");
+        alias(m, "Chicken Broth", "chicken stock", "chicken bone broth");
+        alias(m, "Beef Broth", "beef stock", "beef bone broth");
+        alias(m, "Vegetable Broth", "vegetable stock", "veggie broth", "veggie stock");
+        alias(m, "Coconut Milk", "canned coconut milk", "full fat coconut milk",
+                "coconut milk (canned)");
+        alias(m, "Black Beans", "canned black beans", "black beans (canned)");
+        alias(m, "Kidney Beans", "canned kidney beans", "red kidney beans");
+        alias(m, "Pinto Beans", "canned pinto beans");
+        alias(m, "Chickpeas", "garbanzo beans", "canned chickpeas");
+
+        // --- Nuts & Seeds ---
+        alias(m, "Almonds", "whole almonds", "raw almonds");
+        alias(m, "Sliced Almonds", "slivered almonds");
+        alias(m, "Walnuts", "walnut pieces", "chopped walnuts");
+        alias(m, "Pecans", "pecan pieces", "chopped pecans", "pecan halves");
+        alias(m, "Peanuts", "roasted peanuts", "dry roasted peanuts");
+        alias(m, "Peanut Butter", "creamy peanut butter", "smooth peanut butter");
+        alias(m, "Sesame Seeds", "toasted sesame seeds", "white sesame seeds");
+
+        // --- Frozen ---
+        alias(m, "Frozen Peas", "frozen green peas", "peas (frozen)");
+        alias(m, "Frozen Corn", "frozen sweet corn", "corn (frozen)");
+        alias(m, "Frozen Spinach", "frozen chopped spinach", "spinach (frozen)");
+        alias(m, "Frozen Mixed Vegetables", "frozen mixed veggies", "frozen vegetables");
+        alias(m, "Frozen Berries", "frozen mixed berries");
+
+        ALIASES = Map.copyOf(m);
+    }
+
+    private IngredientAliasDictionary() {}
+
+    public static String resolve(String normalizedName) {
+        if (normalizedName == null || normalizedName.isBlank()) return normalizedName;
+        return ALIASES.getOrDefault(normalizedName.toLowerCase(), normalizedName);
+    }
+
+    public static String resolveAndNormalize(String rawName) {
+        String normalized = IngredientNameNormalizer.normalize(rawName);
+        return resolve(normalized);
+    }
+
+    private static void alias(Map<String, String> map, String canonical, String... aliases) {
+        for (String a : aliases) {
+            map.put(a.toLowerCase(), canonical);
+        }
+    }
+}

--- a/src/main/java/com/endoran/foodplan/service/IngredientLinkerService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientLinkerService.java
@@ -29,6 +29,7 @@ public class IngredientLinkerService {
         for (SharedRecipeIngredient sri : ingredients) {
             if (sri.getIngredientId() != null && !sri.getIngredientId().isBlank()) continue;
 
+            sri.setIngredientName(IngredientAliasDictionary.resolveAndNormalize(sri.getIngredientName()));
             var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, sri.getIngredientName());
             if (existing.isPresent()) {
                 sri.setIngredientId(existing.get().getId());

--- a/src/main/java/com/endoran/foodplan/service/IngredientNameNormalizer.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientNameNormalizer.java
@@ -1,0 +1,62 @@
+package com.endoran.foodplan.service;
+
+import java.util.Set;
+
+public final class IngredientNameNormalizer {
+
+    private static final Set<String> LOWERCASE_WORDS = Set.of(
+            "of", "and", "with", "in", "for", "the", "a", "an", "or");
+
+    private IngredientNameNormalizer() {}
+
+    public static String normalize(String name) {
+        if (name == null || name.isBlank()) return name;
+
+        String cleaned = name.trim()
+                .replaceAll("\\s+", " ")
+                .replaceAll("[.,;:!]+$", "");
+
+        if (cleaned.isEmpty()) return cleaned;
+
+        StringBuilder result = new StringBuilder();
+        boolean inParens = false;
+        String[] words = cleaned.split(" ");
+
+        for (int i = 0; i < words.length; i++) {
+            String word = words[i];
+            if (word.isEmpty()) continue;
+
+            if (result.length() > 0) result.append(' ');
+
+            if (word.startsWith("(")) {
+                inParens = true;
+                result.append('(');
+                word = word.substring(1);
+                if (word.isEmpty()) continue;
+            }
+
+            boolean endsParens = word.endsWith(")");
+            if (endsParens) {
+                word = word.substring(0, word.length() - 1);
+            }
+
+            if (i > 0 && !inParens && LOWERCASE_WORDS.contains(word.toLowerCase())) {
+                result.append(word.toLowerCase());
+            } else {
+                result.append(titleCase(word));
+            }
+
+            if (endsParens) {
+                result.append(')');
+                inParens = false;
+            }
+        }
+
+        return result.toString();
+    }
+
+    private static String titleCase(String word) {
+        if (word.length() == 1) return word.toUpperCase();
+        return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+    }
+}

--- a/src/main/java/com/endoran/foodplan/service/IngredientNameNormalizer.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientNameNormalizer.java
@@ -56,7 +56,19 @@ public final class IngredientNameNormalizer {
     }
 
     private static String titleCase(String word) {
-        if (word.length() == 1) return word.toUpperCase();
-        return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+        if (!word.contains("-")) {
+            if (word.length() == 1) return word.toUpperCase();
+            return Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+        }
+        String[] parts = word.split("-", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) sb.append('-');
+            String p = parts[i];
+            if (p.isEmpty()) continue;
+            sb.append(Character.toUpperCase(p.charAt(0)));
+            if (p.length() > 1) sb.append(p.substring(1).toLowerCase());
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
@@ -41,30 +41,35 @@ public class IngredientNormalizationService {
         List<Merge> merges = new ArrayList<>();
         int skipped = 0;
 
-        Map<String, Ingredient> canonicalMap = new HashMap<>();
+        Map<String, List<Ingredient>> groups = new HashMap<>();
 
         for (Ingredient ing : ingredients) {
             String normalized = IngredientAliasDictionary.resolveAndNormalize(ing.getName());
 
-            boolean changed = false;
             if (!ing.getName().equals(normalized)) {
                 renames.add(new Rename(ing.getId(), ing.getName(), normalized));
-                changed = true;
             }
 
             String key = normalized.toLowerCase();
-            Ingredient existing = canonicalMap.get(key);
-            if (existing == null) {
-                canonicalMap.put(key, ing);
-            } else {
-                Ingredient winner = pickWinner(existing, ing);
-                Ingredient loser = (winner == existing) ? ing : existing;
-                canonicalMap.put(key, winner);
-                merges.add(new Merge(winner.getId(), winner.getName(), loser.getId(), loser.getName(), normalized));
-                changed = true;
+            groups.computeIfAbsent(key, k -> new ArrayList<>()).add(ing);
+        }
+
+        for (Map.Entry<String, List<Ingredient>> entry : groups.entrySet()) {
+            List<Ingredient> group = entry.getValue();
+            if (group.size() < 2) {
+                if (renames.stream().noneMatch(r -> r.ingredientId.equals(group.get(0).getId()))) {
+                    skipped++;
+                }
+                continue;
             }
 
-            if (!changed) skipped++;
+            String canonicalName = IngredientAliasDictionary.resolveAndNormalize(group.get(0).getName());
+            Ingredient winner = group.stream().reduce(this::pickWinner).orElseThrow();
+
+            for (Ingredient loser : group) {
+                if (loser == winner) continue;
+                merges.add(new Merge(winner.getId(), winner.getName(), loser.getId(), loser.getName(), canonicalName));
+            }
         }
 
         if (!dryRun) {
@@ -76,13 +81,17 @@ public class IngredientNormalizationService {
                 }
             }
 
-            for (Merge merge : merges) {
-                repointReferences(orgId, merge.loserId, merge.winnerId, merge.canonicalName);
-                ingredientRepository.deleteById(merge.loserId);
-                Ingredient winner = ingredientRepository.findById(merge.winnerId).orElse(null);
-                if (winner != null && !winner.getName().equals(merge.canonicalName)) {
-                    winner.setName(merge.canonicalName);
-                    ingredientRepository.save(winner);
+            if (!merges.isEmpty()) {
+                List<InventoryItem> allInventory = inventoryItemRepository.findByOrgId(orgId);
+
+                for (Merge merge : merges) {
+                    repointReferences(orgId, merge.loserId, merge.winnerId, merge.canonicalName, allInventory);
+                    ingredientRepository.deleteById(merge.loserId);
+                    Ingredient winner = ingredientRepository.findById(merge.winnerId).orElse(null);
+                    if (winner != null && !winner.getName().equals(merge.canonicalName)) {
+                        winner.setName(merge.canonicalName);
+                        ingredientRepository.save(winner);
+                    }
                 }
             }
         }
@@ -99,7 +108,8 @@ public class IngredientNormalizationService {
         return a.getId().compareTo(b.getId()) <= 0 ? a : b;
     }
 
-    private void repointReferences(String orgId, String loserId, String winnerId, String canonicalName) {
+    private void repointReferences(String orgId, String loserId, String winnerId,
+                                     String canonicalName, List<InventoryItem> allInventory) {
         Query recipeQuery = new Query(Criteria.where("orgId").is(orgId)
                 .and("ingredients.ingredientId").is(loserId));
         Update recipeUpdate = new Update()
@@ -116,7 +126,7 @@ public class IngredientNormalizationService {
                 .filterArray(Criteria.where("elem.ingredientId").is(loserId));
         mongoTemplate.updateMulti(pinnedQuery, pinnedUpdate, "pinned_recipes");
 
-        List<InventoryItem> loserItems = inventoryItemRepository.findByOrgId(orgId).stream()
+        List<InventoryItem> loserItems = allInventory.stream()
                 .filter(item -> loserId.equals(item.getIngredientId()))
                 .toList();
 

--- a/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
@@ -1,0 +1,150 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.model.Ingredient;
+import com.endoran.foodplan.model.InventoryItem;
+import com.endoran.foodplan.repository.IngredientRepository;
+import com.endoran.foodplan.repository.InventoryItemRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class IngredientNormalizationService {
+
+    private static final Logger log = LoggerFactory.getLogger(IngredientNormalizationService.class);
+
+    private final IngredientRepository ingredientRepository;
+    private final InventoryItemRepository inventoryItemRepository;
+    private final MongoTemplate mongoTemplate;
+
+    public IngredientNormalizationService(IngredientRepository ingredientRepository,
+                                          InventoryItemRepository inventoryItemRepository,
+                                          MongoTemplate mongoTemplate) {
+        this.ingredientRepository = ingredientRepository;
+        this.inventoryItemRepository = inventoryItemRepository;
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public NormalizationResult normalizeAll(String orgId, boolean dryRun) {
+        List<Ingredient> ingredients = ingredientRepository.findByOrgId(orgId);
+        List<Rename> renames = new ArrayList<>();
+        List<Merge> merges = new ArrayList<>();
+        int skipped = 0;
+
+        Map<String, Ingredient> canonicalMap = new HashMap<>();
+
+        for (Ingredient ing : ingredients) {
+            String normalized = IngredientAliasDictionary.resolveAndNormalize(ing.getName());
+
+            boolean changed = false;
+            if (!ing.getName().equals(normalized)) {
+                renames.add(new Rename(ing.getId(), ing.getName(), normalized));
+                changed = true;
+            }
+
+            String key = normalized.toLowerCase();
+            Ingredient existing = canonicalMap.get(key);
+            if (existing == null) {
+                canonicalMap.put(key, ing);
+            } else {
+                Ingredient winner = pickWinner(existing, ing);
+                Ingredient loser = (winner == existing) ? ing : existing;
+                canonicalMap.put(key, winner);
+                merges.add(new Merge(winner.getId(), winner.getName(), loser.getId(), loser.getName(), normalized));
+                changed = true;
+            }
+
+            if (!changed) skipped++;
+        }
+
+        if (!dryRun) {
+            for (Rename rename : renames) {
+                Ingredient ing = ingredientRepository.findById(rename.ingredientId).orElse(null);
+                if (ing != null) {
+                    ing.setName(rename.newName);
+                    ingredientRepository.save(ing);
+                }
+            }
+
+            for (Merge merge : merges) {
+                repointReferences(orgId, merge.loserId, merge.winnerId, merge.canonicalName);
+                ingredientRepository.deleteById(merge.loserId);
+                Ingredient winner = ingredientRepository.findById(merge.winnerId).orElse(null);
+                if (winner != null && !winner.getName().equals(merge.canonicalName)) {
+                    winner.setName(merge.canonicalName);
+                    ingredientRepository.save(winner);
+                }
+            }
+        }
+
+        log.info("Normalization for org {}: {} renames, {} merges, {} skipped (dryRun={})",
+                orgId, renames.size(), merges.size(), skipped, dryRun);
+
+        return new NormalizationResult(renames, merges, skipped);
+    }
+
+    private Ingredient pickWinner(Ingredient a, Ingredient b) {
+        if (!a.isNeedsReview() && b.isNeedsReview()) return a;
+        if (a.isNeedsReview() && !b.isNeedsReview()) return b;
+        return a.getId().compareTo(b.getId()) <= 0 ? a : b;
+    }
+
+    private void repointReferences(String orgId, String loserId, String winnerId, String canonicalName) {
+        Query recipeQuery = new Query(Criteria.where("orgId").is(orgId)
+                .and("ingredients.ingredientId").is(loserId));
+        Update recipeUpdate = new Update()
+                .set("ingredients.$[elem].ingredientId", winnerId)
+                .set("ingredients.$[elem].ingredientName", canonicalName)
+                .filterArray(Criteria.where("elem.ingredientId").is(loserId));
+        mongoTemplate.updateMulti(recipeQuery, recipeUpdate, "recipes");
+
+        Query pinnedQuery = new Query(Criteria.where("orgId").is(orgId)
+                .and("ingredients.ingredientId").is(loserId));
+        Update pinnedUpdate = new Update()
+                .set("ingredients.$[elem].ingredientId", winnerId)
+                .set("ingredients.$[elem].ingredientName", canonicalName)
+                .filterArray(Criteria.where("elem.ingredientId").is(loserId));
+        mongoTemplate.updateMulti(pinnedQuery, pinnedUpdate, "pinned_recipes");
+
+        List<InventoryItem> loserItems = inventoryItemRepository.findByOrgId(orgId).stream()
+                .filter(item -> loserId.equals(item.getIngredientId()))
+                .toList();
+
+        for (InventoryItem loserItem : loserItems) {
+            var winnerItem = inventoryItemRepository.findByOrgIdAndIngredientIdAndUnit(
+                    orgId, winnerId, loserItem.getUnit());
+            if (winnerItem.isPresent()) {
+                InventoryItem w = winnerItem.get();
+                w.setQuantity(w.getQuantity().add(loserItem.getQuantity() != null
+                        ? loserItem.getQuantity() : BigDecimal.ZERO));
+                inventoryItemRepository.save(w);
+                inventoryItemRepository.deleteById(loserItem.getId());
+            } else {
+                loserItem.setIngredientId(winnerId);
+                loserItem.setIngredientName(canonicalName);
+                inventoryItemRepository.save(loserItem);
+            }
+        }
+    }
+
+    public record NormalizationResult(
+            List<Rename> renames,
+            List<Merge> merges,
+            int skipped
+    ) {}
+
+    public record Rename(String ingredientId, String oldName, String newName) {}
+
+    public record Merge(String winnerId, String winnerName, String loserId,
+                         String loserName, String canonicalName) {}
+}

--- a/src/main/java/com/endoran/foodplan/service/IngredientService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientService.java
@@ -28,7 +28,7 @@ public class IngredientService {
     public IngredientResponse create(String orgId, CreateIngredientRequest request) {
         Ingredient ingredient = new Ingredient();
         ingredient.setOrgId(orgId);
-        ingredient.setName(request.name());
+        ingredient.setName(IngredientAliasDictionary.resolveAndNormalize(request.name()));
         ingredient.setStorageCategory(request.storageCategory());
         ingredient.setGroceryCategory(request.groceryCategory());
         if (request.dietaryTags() != null) {
@@ -78,32 +78,33 @@ public class IngredientService {
 
     public List<IngredientPreparation> prepareIngredients(String orgId, List<String> ingredientNames) {
         return ingredientNames.stream().map(name -> {
-            var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, name);
+            String normalized = IngredientAliasDictionary.resolveAndNormalize(name);
+            var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, normalized);
             if (existing.isPresent()) {
                 Ingredient ing = existing.get();
                 return new IngredientPreparation(
-                        name, IngredientPreparation.Status.EXISTING,
+                        normalized, IngredientPreparation.Status.EXISTING,
                         ing.getStorageCategory(), ing.getGroceryCategory(),
                         ing.isShoppingListExclude());
             }
             IngredientCategoryInference.InferredCategories inferred =
-                    IngredientCategoryInference.infer(name);
+                    IngredientCategoryInference.infer(normalized);
             return new IngredientPreparation(
-                    name, IngredientPreparation.Status.NEW,
+                    normalized, IngredientPreparation.Status.NEW,
                     inferred.storage(), inferred.grocery(), false);
         }).toList();
     }
 
     public List<IngredientResponse> batchCreate(String orgId, BatchCreateIngredientsRequest request) {
         return request.ingredients().stream().map(entry -> {
-            // Skip if already exists (race condition guard)
-            var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, entry.name());
+            String normalizedName = IngredientAliasDictionary.resolveAndNormalize(entry.name());
+            var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, normalizedName);
             if (existing.isPresent()) {
                 return toResponse(existing.get());
             }
             Ingredient ingredient = new Ingredient();
             ingredient.setOrgId(orgId);
-            ingredient.setName(entry.name());
+            ingredient.setName(normalizedName);
             ingredient.setStorageCategory(entry.storageCategory());
             ingredient.setGroceryCategory(entry.groceryCategory());
             ingredient.setShoppingListExclude(entry.shoppingListExclude());

--- a/src/main/java/com/endoran/foodplan/service/RecipeService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeService.java
@@ -253,6 +253,7 @@ public class RecipeService {
             boolean changed = false;
             for (RecipeIngredient ri : recipe.getIngredients()) {
                 if (ri.getIngredientId() != null && !ri.getIngredientId().isBlank()) continue;
+                ri.setIngredientName(IngredientAliasDictionary.resolveAndNormalize(ri.getIngredientName()));
                 var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(orgId, ri.getIngredientName());
                 if (existing.isPresent()) {
                     ri.setIngredientId(existing.get().getId());
@@ -284,6 +285,7 @@ public class RecipeService {
         for (RecipeIngredient ri : ingredients) {
             if (ri.getIngredientId() != null && !ri.getIngredientId().isBlank()) continue;
 
+            ri.setIngredientName(IngredientAliasDictionary.resolveAndNormalize(ri.getIngredientName()));
             var existing = ingredientRepository.findByOrgIdAndNameIgnoreCase(
                     orgId, ri.getIngredientName());
             if (existing.isPresent()) {

--- a/src/test/java/com/endoran/foodplan/service/IngredientAliasDictionaryTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientAliasDictionaryTest.java
@@ -1,0 +1,93 @@
+package com.endoran.foodplan.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class IngredientAliasDictionaryTest {
+
+    @Test
+    void parmesanAliasResolvesToCheese() {
+        assertEquals("Parmesan Cheese", IngredientAliasDictionary.resolve("parmesan"));
+    }
+
+    @Test
+    void parmiggianoResolves() {
+        assertEquals("Parmesan Cheese", IngredientAliasDictionary.resolve("parmigiano-reggiano"));
+    }
+
+    @Test
+    void scallionResolvesToGreenOnion() {
+        assertEquals("Green Onion", IngredientAliasDictionary.resolve("scallion"));
+    }
+
+    @Test
+    void evooResolvesToOliveOil() {
+        assertEquals("Olive Oil", IngredientAliasDictionary.resolve("evoo"));
+    }
+
+    @Test
+    void unknownNamePassesThrough() {
+        assertEquals("Unicorn Tears", IngredientAliasDictionary.resolve("Unicorn Tears"));
+    }
+
+    @Test
+    void caseInsensitiveLookup() {
+        assertEquals("Ground Beef", IngredientAliasDictionary.resolve("HAMBURGER MEAT"));
+    }
+
+    @Test
+    void kosherSaltStaysDistinct() {
+        assertEquals("Kosher Salt", IngredientAliasDictionary.resolve("Kosher Salt"));
+    }
+
+    @Test
+    void seaSaltStaysDistinct() {
+        assertEquals("Sea Salt", IngredientAliasDictionary.resolve("Sea Salt"));
+    }
+
+    @Test
+    void resolveAndNormalizeFullPipeline() {
+        assertEquals("Green Onion", IngredientAliasDictionary.resolveAndNormalize("  SCALLIONS  "));
+    }
+
+    @Test
+    void resolveAndNormalizeUnknown() {
+        assertEquals("Pink Himalayan Salt", IngredientAliasDictionary.resolveAndNormalize("pink himalayan salt"));
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertNull(IngredientAliasDictionary.resolve(null));
+    }
+
+    @Test
+    void blankPassesThrough() {
+        assertEquals("  ", IngredientAliasDictionary.resolve("  "));
+    }
+
+    @Test
+    void heavyCreamAlias() {
+        assertEquals("Heavy Cream", IngredientAliasDictionary.resolve("heavy whipping cream"));
+    }
+
+    @Test
+    void allPurposeFlourVariants() {
+        assertEquals("All-Purpose Flour", IngredientAliasDictionary.resolve("ap flour"));
+        assertEquals("All-Purpose Flour", IngredientAliasDictionary.resolve("plain flour"));
+        assertEquals("All-Purpose Flour", IngredientAliasDictionary.resolve("flour"));
+    }
+
+    @Test
+    void groundBeefVariants() {
+        assertEquals("Ground Beef", IngredientAliasDictionary.resolve("hamburger meat"));
+        assertEquals("Ground Beef", IngredientAliasDictionary.resolve("ground chuck"));
+        assertEquals("Ground Beef", IngredientAliasDictionary.resolve("beef mince"));
+    }
+
+    @Test
+    void chickpeasGarbanzoBeans() {
+        assertEquals("Chickpeas", IngredientAliasDictionary.resolve("garbanzo beans"));
+    }
+}

--- a/src/test/java/com/endoran/foodplan/service/IngredientNameNormalizerTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientNameNormalizerTest.java
@@ -1,0 +1,91 @@
+package com.endoran.foodplan.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class IngredientNameNormalizerTest {
+
+    @Test
+    void basicTitleCase() {
+        assertEquals("Kosher Salt", IngredientNameNormalizer.normalize("kosher salt"));
+    }
+
+    @Test
+    void allCapsToTitleCase() {
+        assertEquals("Kosher Salt", IngredientNameNormalizer.normalize("KOSHER SALT"));
+    }
+
+    @Test
+    void mixedCaseNormalized() {
+        assertEquals("Red Bell Pepper", IngredientNameNormalizer.normalize("rEd BELL pepper"));
+    }
+
+    @Test
+    void lowercaseArticles() {
+        assertEquals("Salt and Pepper", IngredientNameNormalizer.normalize("salt and pepper"));
+    }
+
+    @Test
+    void lowercasePrepositions() {
+        assertEquals("Cream of Mushroom Soup", IngredientNameNormalizer.normalize("cream of mushroom soup"));
+    }
+
+    @Test
+    void firstWordAlwaysCapitalized() {
+        assertEquals("A Pinch of Salt", IngredientNameNormalizer.normalize("a pinch of salt"));
+    }
+
+    @Test
+    void collapsesWhitespace() {
+        assertEquals("Garlic Powder", IngredientNameNormalizer.normalize("  garlic   powder  "));
+    }
+
+    @Test
+    void stripsTrailingPunctuation() {
+        assertEquals("Garlic Powder", IngredientNameNormalizer.normalize("garlic powder."));
+        assertEquals("Garlic Powder", IngredientNameNormalizer.normalize("garlic powder,"));
+        assertEquals("Garlic Powder", IngredientNameNormalizer.normalize("garlic powder;"));
+    }
+
+    @Test
+    void parentheticalHandling() {
+        assertEquals("Parmesan Cheese (Powder)", IngredientNameNormalizer.normalize("parmesan cheese (powder)"));
+    }
+
+    @Test
+    void parentheticalFirstWordCapitalized() {
+        assertEquals("Red Pepper (Diced)", IngredientNameNormalizer.normalize("red pepper (diced)"));
+    }
+
+    @Test
+    void hyphenatedWordsPreserved() {
+        assertEquals("All-purpose Flour", IngredientNameNormalizer.normalize("all-purpose flour"));
+    }
+
+    @Test
+    void singleWord() {
+        assertEquals("Cilantro", IngredientNameNormalizer.normalize("cilantro"));
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertNull(IngredientNameNormalizer.normalize(null));
+    }
+
+    @Test
+    void blankReturnsBlank() {
+        assertEquals("   ", IngredientNameNormalizer.normalize("   "));
+    }
+
+    @Test
+    void emptyReturnsEmpty() {
+        assertEquals("", IngredientNameNormalizer.normalize(""));
+    }
+
+    @Test
+    void alreadyNormalized() {
+        assertEquals("Chicken Breast", IngredientNameNormalizer.normalize("Chicken Breast"));
+    }
+}

--- a/src/test/java/com/endoran/foodplan/service/IngredientNameNormalizerTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientNameNormalizerTest.java
@@ -61,7 +61,7 @@ class IngredientNameNormalizerTest {
 
     @Test
     void hyphenatedWordsPreserved() {
-        assertEquals("All-purpose Flour", IngredientNameNormalizer.normalize("all-purpose flour"));
+        assertEquals("All-Purpose Flour", IngredientNameNormalizer.normalize("all-purpose flour"));
     }
 
     @Test

--- a/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
@@ -1,0 +1,117 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.model.GroceryCategory;
+import com.endoran.foodplan.model.Ingredient;
+import com.endoran.foodplan.model.InventoryItem;
+import com.endoran.foodplan.model.MeasurementUnit;
+import com.endoran.foodplan.repository.IngredientRepository;
+import com.endoran.foodplan.repository.InventoryItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IngredientNormalizationServiceTest {
+
+    @Mock private IngredientRepository ingredientRepository;
+    @Mock private InventoryItemRepository inventoryItemRepository;
+    @Mock private MongoTemplate mongoTemplate;
+
+    private IngredientNormalizationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IngredientNormalizationService(ingredientRepository, inventoryItemRepository, mongoTemplate);
+    }
+
+    @Test
+    void dryRunDoesNotMutate() {
+        Ingredient ing = makeIngredient("1", "kosher salt", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+
+        var result = service.normalizeAll("org1", true);
+
+        assertEquals(1, result.renames().size());
+        assertEquals("kosher salt", result.renames().get(0).oldName());
+        assertEquals("Kosher Salt", result.renames().get(0).newName());
+        verify(ingredientRepository, never()).save(any());
+        verify(ingredientRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void renameOnlyNoDuplicates() {
+        Ingredient ing = makeIngredient("1", "garlic powder", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+        when(ingredientRepository.findById("1")).thenReturn(Optional.of(ing));
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(1, result.renames().size());
+        assertEquals("Garlic Powder", result.renames().get(0).newName());
+        verify(ingredientRepository).save(ing);
+        assertEquals("Garlic Powder", ing.getName());
+    }
+
+    @Test
+    void mergesDuplicatesKeepsReviewedWinner() {
+        Ingredient reviewed = makeIngredient("1", "Garlic Powder", false);
+        Ingredient unreviewed = makeIngredient("2", "garlic powder", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(reviewed, unreviewed));
+        when(ingredientRepository.findById("1")).thenReturn(Optional.of(reviewed));
+        when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of());
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(1, result.merges().size());
+        assertEquals("1", result.merges().get(0).winnerId());
+        assertEquals("2", result.merges().get(0).loserId());
+        verify(ingredientRepository).deleteById("2");
+    }
+
+    @Test
+    void aliasResolutionTriggersRename() {
+        Ingredient ing = makeIngredient("1", "scallions", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+        when(ingredientRepository.findById("1")).thenReturn(Optional.of(ing));
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(1, result.renames().size());
+        assertEquals("Green Onion", result.renames().get(0).newName());
+    }
+
+    @Test
+    void alreadyNormalizedSkipped() {
+        Ingredient ing = makeIngredient("1", "Chicken Breast", false);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(0, result.renames().size());
+        assertEquals(0, result.merges().size());
+    }
+
+    private Ingredient makeIngredient(String id, String name, boolean needsReview) {
+        Ingredient ing = new Ingredient();
+        ing.setId(id);
+        ing.setOrgId("org1");
+        ing.setName(name);
+        ing.setNeedsReview(needsReview);
+        ing.setGroceryCategory(GroceryCategory.PRODUCE);
+        return ing;
+    }
+}

--- a/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
@@ -71,7 +71,12 @@ class IngredientNormalizationServiceTest {
         Ingredient reviewed = makeIngredient("1", "Garlic Powder", false);
         Ingredient unreviewed = makeIngredient("2", "garlic powder", true);
         when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(reviewed, unreviewed));
-        when(ingredientRepository.findById("1")).thenReturn(Optional.of(reviewed));
+        when(ingredientRepository.findById(anyString())).thenAnswer(inv -> {
+            String id = inv.getArgument(0);
+            if ("1".equals(id)) return Optional.of(reviewed);
+            if ("2".equals(id)) return Optional.of(unreviewed);
+            return Optional.empty();
+        });
         when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of());
 
         var result = service.normalizeAll("org1", false);
@@ -103,6 +108,96 @@ class IngredientNormalizationServiceTest {
 
         assertEquals(0, result.renames().size());
         assertEquals(0, result.merges().size());
+    }
+
+    @Test
+    void threeWayMergeAllLosersPointToSingleWinner() {
+        Ingredient a = makeIngredient("1", "garlic powder", true);
+        Ingredient b = makeIngredient("2", "Garlic Powder", false);
+        Ingredient c = makeIngredient("3", "GARLIC POWDER", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(a, b, c));
+        when(ingredientRepository.findById(anyString())).thenAnswer(inv -> {
+            String id = inv.getArgument(0);
+            if ("1".equals(id)) return Optional.of(a);
+            if ("2".equals(id)) return Optional.of(b);
+            if ("3".equals(id)) return Optional.of(c);
+            return Optional.empty();
+        });
+        when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of());
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(2, result.merges().size());
+        for (var merge : result.merges()) {
+            assertEquals("2", merge.winnerId());
+        }
+        var loserIds = result.merges().stream().map(m -> m.loserId()).sorted().toList();
+        assertEquals(List.of("1", "3"), loserIds);
+        verify(ingredientRepository).deleteById("1");
+        verify(ingredientRepository).deleteById("3");
+    }
+
+    @Test
+    void inventoryMergesSameUnitSumsQuantities() {
+        Ingredient reviewed = makeIngredient("1", "Garlic Powder", false);
+        Ingredient unreviewed = makeIngredient("2", "garlic powder", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(reviewed, unreviewed));
+        when(ingredientRepository.findById(anyString())).thenAnswer(inv -> {
+            String id = inv.getArgument(0);
+            if ("1".equals(id)) return Optional.of(reviewed);
+            if ("2".equals(id)) return Optional.of(unreviewed);
+            return Optional.empty();
+        });
+
+        InventoryItem winnerItem = new InventoryItem();
+        winnerItem.setId("inv1");
+        winnerItem.setOrgId("org1");
+        winnerItem.setIngredientId("1");
+        winnerItem.setUnit(MeasurementUnit.TSP);
+        winnerItem.setQuantity(new BigDecimal("2.5"));
+
+        InventoryItem loserItem = new InventoryItem();
+        loserItem.setId("inv2");
+        loserItem.setOrgId("org1");
+        loserItem.setIngredientId("2");
+        loserItem.setUnit(MeasurementUnit.TSP);
+        loserItem.setQuantity(new BigDecimal("1.5"));
+
+        when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of(winnerItem, loserItem));
+        when(inventoryItemRepository.findByOrgIdAndIngredientIdAndUnit("org1", "1", MeasurementUnit.TSP))
+                .thenReturn(Optional.of(winnerItem));
+
+        service.normalizeAll("org1", false);
+
+        assertEquals(new BigDecimal("4.0"), winnerItem.getQuantity());
+        verify(inventoryItemRepository).save(winnerItem);
+        verify(inventoryItemRepository).deleteById("inv2");
+    }
+
+    @Test
+    void mergeRepointsRecipeAndPinnedRecipeReferences() {
+        Ingredient reviewed = makeIngredient("1", "Garlic Powder", false);
+        Ingredient unreviewed = makeIngredient("2", "garlic powder", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(reviewed, unreviewed));
+        when(ingredientRepository.findById(anyString())).thenAnswer(inv -> {
+            String id = inv.getArgument(0);
+            if ("1".equals(id)) return Optional.of(reviewed);
+            if ("2".equals(id)) return Optional.of(unreviewed);
+            return Optional.empty();
+        });
+        when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of());
+
+        service.normalizeAll("org1", false);
+
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+        ArgumentCaptor<String> collectionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mongoTemplate, times(2)).updateMulti(
+                queryCaptor.capture(), updateCaptor.capture(), collectionCaptor.capture());
+
+        var collections = collectionCaptor.getAllValues();
+        assertTrue(collections.contains("recipes"));
+        assertTrue(collections.contains("pinned_recipes"));
     }
 
     private Ingredient makeIngredient(String id, String name, boolean needsReview) {


### PR DESCRIPTION
## Summary
- **IngredientNameNormalizer** — Title Case with lowercase articles (of, and, with, etc.), whitespace collapse, trailing punctuation removal, parenthetical handling
- **IngredientAliasDictionary** — ~170 static alias entries mapping ingredient variants to canonical names (e.g. "scallion" → "Green Onion", "evoo" → "Olive Oil"). Distinct variants like sea salt/kosher salt/table salt are preserved as separate ingredients
- **Inline normalization** — All 5 ingredient creation paths now run `resolveAndNormalize()` before lookup/save: RecipeService, GlobalRecipeService, IngredientLinkerService, IngredientService (create + batchCreate + prepare)
- **Batch normalization service** — `POST /api/v1/ingredients/normalize?dryRun=true|false` scans all org ingredients, renames to canonical form, merges duplicates (repoints references in recipes, pinned recipes, and inventory items). Merge winner prefers reviewed ingredients. Dry-run returns preview without mutations
- **Frontend** — "Normalize Names" button on Ingredients page shows dry-run preview (renames + merges), then applies on confirm

## Test plan
- [ ] Import recipe with "parmesan cheese powder" — should auto-normalize name
- [ ] Import recipe with "scallions" — should resolve to "Green Onion" via alias
- [ ] Create ingredient manually with "GARLIC powder" — should save as "Garlic Powder"
- [ ] Click "Normalize Names" on Ingredients page — dry-run preview appears
- [ ] Confirm normalize — duplicates merge, ingredient list refreshes
- [ ] Verify recipes still reference correct ingredient after merge
- [ ] Verify inventory items merge quantities when same unit
- [ ] Unit tests: `IngredientNameNormalizerTest`, `IngredientAliasDictionaryTest`, `IngredientNormalizationServiceTest`