### PR TITLE
Add app version footer, align version to v1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.endoran'
-version = '0.1.0'
+version = '1.4.0'
 
 java {
     toolchain {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foodplan-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -8,6 +8,9 @@ export function Layout() {
       <main className="content">
         <Outlet />
       </main>
+      <footer className="app-footer">
+        v{__APP_VERSION__} · {new Date(__BUILD_TIME__).toLocaleDateString()}
+      </footer>
     </div>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles/index.css';
 
-(window as any).__APP_VERSION__ = '1775633841';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -435,3 +435,11 @@ body {
   color: var(--text);
   cursor: pointer;
 }
+
+/* App Footer */
+.app-footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __BUILD_TIME__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
   plugins: [react()],
   define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
     __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
   },
   server: {


### PR DESCRIPTION
## Summary
- Inject version from `package.json` via Vite `define` (replaces hardcoded timestamp in main.tsx)
- Add footer to Layout component showing `v1.4.0 · <build date>`
- Align `package.json` and `build.gradle` versions to 1.4.0

## Test plan
- [ ] Footer visible on every page (bottom of viewport)
- [ ] Version reads "v1.4.0"
- [ ] Build date is human-readable
- [ ] `npx tsc --noEmit` passes