### PR TITLE
Authoritative ingredient knowledge base (349 profiles)

### DIFF
--- a/frontend/src/recipes/IngredientListPage.tsx
+++ b/frontend/src/recipes/IngredientListPage.tsx
@@ -7,6 +7,7 @@ import type { Ingredient } from './types';
 interface NormalizationResult {
   renames: { ingredientId: string; oldName: string; newName: string }[];
   merges: { winnerId: string; winnerName: string; loserId: string; loserName: string; canonicalName: string }[];
+  categoryFixes: { ingredientId: string; ingredientName: string; oldStorage: string; newStorage: string; oldGrocery: string; newGrocery: string; oldTags: string[]; newTags: string[] }[];
   skipped: number;
 }
 
@@ -103,7 +104,7 @@ export function IngredientListPage() {
       {normalizePreview && (
         <div className="normalize-preview">
           <h3>Normalization Preview</h3>
-          {normalizePreview.renames.length === 0 && normalizePreview.merges.length === 0 ? (
+          {normalizePreview.renames.length === 0 && normalizePreview.merges.length === 0 && normalizePreview.categoryFixes.length === 0 ? (
             <p className="muted">All ingredient names are already normalized.</p>
           ) : (
             <>
@@ -124,6 +125,18 @@ export function IngredientListPage() {
                     {normalizePreview.merges.map(m => (
                       <li key={m.loserId}>
                         "{m.loserName}" will merge into "{m.winnerName}" &rarr; {m.canonicalName}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {normalizePreview.categoryFixes.length > 0 && (
+                <div>
+                  <h4>Category Fixes ({normalizePreview.categoryFixes.length})</h4>
+                  <ul>
+                    {normalizePreview.categoryFixes.map(f => (
+                      <li key={f.ingredientId}>
+                        {f.ingredientName}: {formatEnum(f.oldGrocery)} &rarr; {formatEnum(f.newGrocery)}, {formatEnum(f.oldStorage)} &rarr; {formatEnum(f.newStorage)}
                       </li>
                     ))}
                   </ul>

--- a/src/main/java/com/endoran/foodplan/dto/IngredientPreparation.java
+++ b/src/main/java/com/endoran/foodplan/dto/IngredientPreparation.java
@@ -1,13 +1,17 @@
 package com.endoran.foodplan.dto;
 
+import com.endoran.foodplan.model.DietaryTag;
 import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.model.StorageCategory;
+
+import java.util.Set;
 
 public record IngredientPreparation(
         String name,
         Status status,
         StorageCategory storageCategory,
         GroceryCategory groceryCategory,
+        Set<DietaryTag> dietaryTags,
         boolean shoppingListExclude
 ) {
     public enum Status { EXISTING, NEW }

--- a/src/main/java/com/endoran/foodplan/service/GlobalRecipeService.java
+++ b/src/main/java/com/endoran/foodplan/service/GlobalRecipeService.java
@@ -362,6 +362,8 @@ public class GlobalRecipeService {
                         }
                     }
                     newIng.setDietaryTags(tags);
+                } else {
+                    newIng.setDietaryTags(IngredientCategoryInference.infer(ri.getIngredientName()).dietaryTags());
                 }
 
                 newIng.setNeedsReview(false);

--- a/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientAliasDictionary.java
@@ -12,7 +12,9 @@ public final class IngredientAliasDictionary {
 
         // --- Dairy ---
         alias(m, "Parmesan Cheese", "parmigiano-reggiano", "parmigiano reggiano", "parmesan",
-                "parm cheese", "grated parmesan", "shredded parmesan");
+                "parm cheese", "grated parmesan", "shredded parmesan",
+                "parmesan cheese (powder-style)", "powder-style parmesan",
+                "cheese (from the green can)");
         alias(m, "Heavy Cream", "heavy whipping cream", "whipping cream");
         alias(m, "Cream Cheese", "cream cheese spread", "neufchatel");
         alias(m, "Sour Cream", "soured cream");
@@ -37,7 +39,7 @@ public final class IngredientAliasDictionary {
                 "skinless chicken breast", "chicken breasts");
         alias(m, "Chicken Thighs", "boneless skinless chicken thighs", "boneless chicken thighs",
                 "chicken thigh");
-        alias(m, "Whole Chicken", "roasting chicken", "whole fryer");
+        alias(m, "Whole Chicken", "roasting chicken", "whole fryer", "whole young chicken");
         alias(m, "Bacon", "bacon strips", "sliced bacon", "thick cut bacon");
         alias(m, "Italian Sausage", "italian sausage links", "sweet italian sausage",
                 "hot italian sausage", "mild italian sausage");
@@ -47,6 +49,8 @@ public final class IngredientAliasDictionary {
         alias(m, "Salmon Fillet", "salmon", "salmon filet", "fresh salmon");
         alias(m, "Shrimp", "prawns", "raw shrimp", "large shrimp", "jumbo shrimp");
         alias(m, "Tofu", "firm tofu", "extra firm tofu");
+        alias(m, "Cooked Chicken Breast", "cooked chicken breast (diced)",
+                "diced cooked chicken breast", "cooked chicken (diced)");
 
         // --- Produce ---
         alias(m, "Green Onion", "scallion", "scallions", "spring onion", "spring onions",
@@ -63,6 +67,8 @@ public final class IngredientAliasDictionary {
                 "jalapenos", "jalapeños");
         alias(m, "Fresh Ginger", "ginger", "ginger root", "gingerroot");
         alias(m, "Lemon", "lemons", "fresh lemon");
+        alias(m, "Lemon Juice", "fresh lemon juice", "bottled lemon juice");
+        alias(m, "Lime Juice", "fresh lime juice", "bottled lime juice");
         alias(m, "Lime", "limes", "fresh lime");
         alias(m, "Roma Tomato", "roma tomatoes", "plum tomato", "plum tomatoes");
         alias(m, "Cherry Tomatoes", "grape tomatoes", "cherry tomato");
@@ -182,6 +188,10 @@ public final class IngredientAliasDictionary {
         alias(m, "Frozen Spinach", "frozen chopped spinach", "spinach (frozen)");
         alias(m, "Frozen Mixed Vegetables", "frozen mixed veggies", "frozen vegetables");
         alias(m, "Frozen Berries", "frozen mixed berries");
+
+        // --- Household ---
+        alias(m, "Water", "cold water", "warm water", "hot water", "ice water",
+                "lukewarm water", "room temperature water");
 
         ALIASES = Map.copyOf(m);
     }

--- a/src/main/java/com/endoran/foodplan/service/IngredientCategoryInference.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientCategoryInference.java
@@ -1,56 +1,91 @@
 package com.endoran.foodplan.service;
 
+import com.endoran.foodplan.model.DietaryTag;
 import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.model.StorageCategory;
 
 import java.util.List;
+import java.util.Set;
+
+import static com.endoran.foodplan.model.DietaryTag.*;
 
 public final class IngredientCategoryInference {
 
-    public record InferredCategories(StorageCategory storage, GroceryCategory grocery) {}
+    public record InferredCategories(StorageCategory storage, GroceryCategory grocery,
+                                     Set<DietaryTag> dietaryTags) {}
 
-    private record Rule(List<String> keywords, StorageCategory storage, GroceryCategory grocery) {}
+    private record Rule(List<String> keywords, StorageCategory storage, GroceryCategory grocery,
+                        Set<DietaryTag> dietaryTags) {}
+
+    private static final Set<DietaryTag> ALL_CLEAR = Set.of(GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+    private static final Set<DietaryTag> MEAT_TAGS = Set.of(GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+    private static final Set<DietaryTag> DAIRY_TAGS = Set.of(GLUTEN_FREE, NUT_FREE, VEGETARIAN);
 
     private static final List<Rule> RULES = List.of(
             new Rule(List.of("frozen"),
-                    StorageCategory.FROZEN, GroceryCategory.FROZEN),
+                    StorageCategory.FROZEN, GroceryCategory.FROZEN, ALL_CLEAR),
             new Rule(List.of("stock", "broth", "canned", "diced tomatoes", "tomato paste",
                     "tomato sauce", "coconut milk"),
-                    StorageCategory.PANTRY, GroceryCategory.CANNED),
+                    StorageCategory.PANTRY, GroceryCategory.CANNED, ALL_CLEAR),
             new Rule(List.of("cream", "milk", "cheese", "yogurt", "butter", "sour cream"),
-                    StorageCategory.REFRIGERATED, GroceryCategory.DAIRY),
+                    StorageCategory.REFRIGERATED, GroceryCategory.DAIRY, DAIRY_TAGS),
             new Rule(List.of("chicken", "beef", "pork", "turkey", "sausage", "bacon",
-                    "lamb", "fish", "salmon", "shrimp"),
-                    StorageCategory.REFRIGERATED, GroceryCategory.MEAT),
+                    "lamb", "fish", "salmon", "shrimp", "tilapia", "cod"),
+                    StorageCategory.REFRIGERATED, GroceryCategory.MEAT, MEAT_TAGS),
             new Rule(List.of("cumin", "paprika", "oregano", "thyme", "rosemary", "cinnamon",
                     "nutmeg", "cayenne", "chili powder", "garlic powder", "onion powder",
                     "turmeric", "masala", "salt", "pepper flakes", "seasoning", "garam",
-                    "red pepper", "black pepper", "white pepper"),
-                    StorageCategory.SPICE_RACK, GroceryCategory.SPICES),
+                    "red pepper", "black pepper", "white pepper", "curry", "allspice",
+                    "cardamom", "cloves", "coriander", "mustard seed"),
+                    StorageCategory.SPICE_RACK, GroceryCategory.SPICES, ALL_CLEAR),
             new Rule(List.of("oil", "vinegar", "soy sauce", "mustard", "ketchup",
-                    "mayonnaise", "honey"),
-                    StorageCategory.PANTRY, GroceryCategory.OILS_CONDIMENTS),
+                    "mayonnaise", "honey", "worcestershire", "fish sauce", "hot sauce",
+                    "sriracha", "bbq sauce", "hoisin", "teriyaki", "anchovy paste",
+                    "tahini", "miso", "ghee", "lemon juice", "lime juice"),
+                    StorageCategory.PANTRY, GroceryCategory.OILS_CONDIMENTS, ALL_CLEAR),
             new Rule(List.of("flour", "sugar", "baking soda", "baking powder", "vanilla",
-                    "cocoa"),
-                    StorageCategory.PANTRY, GroceryCategory.BAKING),
-            new Rule(List.of("cilantro", "basil", "parsley", "mint", "dill", "chives"),
-                    StorageCategory.FRESH, GroceryCategory.PRODUCE),
+                    "cocoa", "cornstarch", "breadcrumb", "panko", "yeast",
+                    "pasta", "spaghetti", "penne", "macaroni", "noodle", "rice",
+                    "oats", "quinoa"),
+                    StorageCategory.PANTRY, GroceryCategory.BAKING, ALL_CLEAR),
+            new Rule(List.of("almond", "walnut", "pecan", "peanut", "cashew", "pistachio",
+                    "pine nut", "hazelnut", "macadamia"),
+                    StorageCategory.PANTRY, GroceryCategory.BULK, Set.of(GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN)),
+            new Rule(List.of("cilantro", "basil", "parsley", "mint", "dill", "chives",
+                    "sage", "lemongrass"),
+                    StorageCategory.FRESH, GroceryCategory.PRODUCE, ALL_CLEAR),
+            new Rule(List.of("lettuce", "spinach", "kale", "arugula", "cabbage",
+                    "broccoli", "cauliflower", "zucchini", "bell pepper", "cucumber",
+                    "celery", "carrot", "mushroom", "asparagus", "green bean",
+                    "brussels sprout", "bok choy", "radish", "leek", "okra"),
+                    StorageCategory.FRESH, GroceryCategory.PRODUCE, ALL_CLEAR),
             new Rule(List.of("garlic", "onion", "potato", "tomato", "banana", "avocado",
-                    "shallot"),
-                    StorageCategory.COUNTER, GroceryCategory.PRODUCE)
+                    "shallot", "ginger", "lemon", "lime", "apple", "orange"),
+                    StorageCategory.COUNTER, GroceryCategory.PRODUCE, ALL_CLEAR),
+            new Rule(List.of("bread", "bun", "tortilla", "pita", "naan", "croissant",
+                    "muffin", "bagel"),
+                    StorageCategory.COUNTER, GroceryCategory.BAKERY, Set.of(DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN)),
+            new Rule(List.of("tea", "coffee", "matcha"),
+                    StorageCategory.PANTRY, GroceryCategory.HOUSEHOLD, ALL_CLEAR)
     );
 
     private static final InferredCategories DEFAULT =
-            new InferredCategories(StorageCategory.PANTRY, GroceryCategory.PRODUCE);
+            new InferredCategories(StorageCategory.PANTRY, GroceryCategory.PRODUCE, ALL_CLEAR);
 
     private IngredientCategoryInference() {}
 
     public static InferredCategories infer(String ingredientName) {
+        var profile = IngredientKnowledgeBase.lookup(ingredientName);
+        if (profile.isPresent()) {
+            var p = profile.get();
+            return new InferredCategories(p.storage(), p.grocery(), p.dietaryTags());
+        }
+
         String lower = ingredientName.toLowerCase();
         for (Rule rule : RULES) {
             for (String keyword : rule.keywords()) {
                 if (lower.contains(keyword)) {
-                    return new InferredCategories(rule.storage(), rule.grocery());
+                    return new InferredCategories(rule.storage(), rule.grocery(), rule.dietaryTags());
                 }
             }
         }

--- a/src/main/java/com/endoran/foodplan/service/IngredientKnowledgeBase.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientKnowledgeBase.java
@@ -1,0 +1,438 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.model.DietaryTag;
+import com.endoran.foodplan.model.GroceryCategory;
+import com.endoran.foodplan.model.StorageCategory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.endoran.foodplan.model.DietaryTag.*;
+import static com.endoran.foodplan.model.GroceryCategory.*;
+import static com.endoran.foodplan.model.StorageCategory.*;
+
+public final class IngredientKnowledgeBase {
+
+    public record IngredientProfile(
+            StorageCategory storage,
+            GroceryCategory grocery,
+            Set<DietaryTag> dietaryTags
+    ) {}
+
+    private static final Map<String, IngredientProfile> PROFILES;
+
+    static {
+        Map<String, IngredientProfile> m = new HashMap<>();
+
+        // ===== DAIRY =====
+        profile(m, "Butter", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Cheddar Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Cottage Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Cream Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Eggs", REFRIGERATED, DAIRY, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Gruyere Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Half and Half", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Heavy Cream", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Monterey Jack Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Mozzarella Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Parmesan Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Pepper Jack Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Plain Yogurt", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Ricotta Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Sour Cream", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Swiss Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Whole Milk", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Evaporated Milk", PANTRY, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Sweetened Condensed Milk", PANTRY, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Whipped Cream", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Goat Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Blue Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Feta Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Provolone Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Colby Jack Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Brie Cheese", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Mascarpone", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Buttermilk", REFRIGERATED, DAIRY, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Ghee", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+
+        // ===== PROTEINS — MEAT =====
+        profile(m, "Bacon", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chicken Breast", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chicken Thighs", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chicken", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Cooked Chicken Breast", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ground Beef", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ground Pork", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ground Turkey", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Italian Sausage", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Pork Chops", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Salmon Fillet", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Shrimp", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Tofu", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Whole Chicken", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Whole Young Chicken", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ham", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Turkey Breast", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Lamb Chops", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ground Lamb", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Stew Meat", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Flank Steak", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Ribeye Steak", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Sirloin Steak", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chuck Roast", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Pork Tenderloin", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Pork Shoulder", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Baby Back Ribs", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chicken Wings", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Chicken Drumsticks", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Tilapia", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Cod", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Tuna Steak", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Crab Meat", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Scallops", REFRIGERATED, MEAT, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Anchovy Paste", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Canned Tuna", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Pepperoni", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Prosciutto", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Salami", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+
+        // ===== PRODUCE — FRESH =====
+        profile(m, "Avocado", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Bell Pepper", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Broccoli", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cabbage", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Carrot", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cauliflower", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Celery", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cherry Tomatoes", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Corn", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cucumber", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Eggplant", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Green Beans", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Green Onion", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Jalapeno", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Kale", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mushrooms", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Rainbow Bell Peppers", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Red Onion", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Roma Tomato", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Romaine Lettuce", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Spinach", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sweet Potato", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tomatoes", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Yellow Onion", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Zucchini", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Asparagus", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Brussels Sprouts", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Butternut Squash", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Acorn Squash", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Snap Peas", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Snow Peas", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Artichoke", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Beets", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Bok Choy", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Radishes", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Turnips", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fennel", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Leeks", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Okra", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Diced Okra", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Iceberg Lettuce", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mixed Greens", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Arugula", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Watercress", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== PRODUCE — COUNTER =====
+        profile(m, "Garlic", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Russet Potato", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Ginger", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Shallot", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== PRODUCE — FRUITS =====
+        profile(m, "Lemon", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Lime", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Apple", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Banana", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Orange", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Strawberries", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Blueberries", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Raspberries", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Grapes", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pineapple", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mango", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Peach", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pear", COUNTER, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== FRESH HERBS =====
+        profile(m, "Cilantro", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Basil", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Dill", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Parsley", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Rosemary", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Thyme", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Mint", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Sage", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fresh Chives", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Lemongrass", FRESH, PRODUCE, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== SPICES & SEASONINGS =====
+        profile(m, "Bay Leaves", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cayenne Pepper", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chili Powder", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Dried Basil", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Dried Oregano", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Garam Masala", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Garlic Powder", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Black Pepper", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Cinnamon", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Cumin", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Ginger", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Nutmeg", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Turmeric", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Italian Seasoning", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Onion Powder", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Paprika", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Powdered Mustard", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Red Pepper Flakes", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Smoked Paprika", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Kosher Salt", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Salt", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Sea Salt", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Mineral Salt", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Celery Salt", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Coriander", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cumin Seeds", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Curry Powder", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Five Spice Powder", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Allspice", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Cardamom", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground Cloves", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ground White Pepper", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mustard Seeds", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Saffron", SPICE_RACK, SPICES, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Taco Seasoning", SPICE_RACK, SPICES, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Old Bay Seasoning", SPICE_RACK, SPICES, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Ranch Seasoning", SPICE_RACK, SPICES, NUT_FREE);
+        profile(m, "Everything Bagel Seasoning", SPICE_RACK, SPICES, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== OILS & CONDIMENTS =====
+        profile(m, "Olive Oil", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Vegetable Oil", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sesame Oil", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Coconut Oil", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Avocado Oil", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Soy Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fish Sauce", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Worcestershire Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE);
+        profile(m, "Hot Sauce", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sriracha", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Dijon Mustard", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Yellow Mustard", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ketchup", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mayonnaise", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Apple Cider Vinegar", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "White Vinegar", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Red Wine Vinegar", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Rice Vinegar", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Balsamic Vinegar", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Honey", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Maple Syrup", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Lemon Juice", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Lime Juice", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Oyster Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE);
+        profile(m, "Hoisin Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Teriyaki Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE);
+        profile(m, "BBQ Sauce", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Salsa", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tahini", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Miso Paste", PANTRY, OILS_CONDIMENTS, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tomato Ketchup", PANTRY, OILS_CONDIMENTS, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pesto", REFRIGERATED, OILS_CONDIMENTS, NUT_FREE, VEGETARIAN);
+
+        // ===== PANTRY — BAKING =====
+        profile(m, "All-Purpose Flour", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Bread Flour", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cake Flour", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Whole Wheat Flour", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Almond Flour", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Coconut Flour", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Granulated Sugar", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Brown Sugar", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Powdered Sugar", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Baking Soda", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Baking Powder", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Vanilla Extract", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Almond Extract", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cornstarch", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cocoa Powder", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chocolate Chips", PANTRY, BAKING, NUT_FREE, VEGETARIAN);
+        profile(m, "Yeast", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Active Dry Yeast", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cream of Tartar", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Gelatin", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, SUGAR_FREE);
+        profile(m, "Food Coloring", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== PANTRY — GRAINS & PASTA =====
+        profile(m, "White Rice", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Brown Rice", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Jasmine Rice", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Basmati Rice", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Arborio Rice", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Quinoa", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Couscous", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Oats", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pasta", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Spaghetti", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Elbow Macaroni", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Penne", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Linguine", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Fettuccine", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Lasagna Noodles", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Egg Noodles", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Rice Noodles", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tortillas", PANTRY, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Flour Tortillas", PANTRY, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Corn Tortillas", PANTRY, BAKERY, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Panko Breadcrumbs", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Breadcrumbs", PANTRY, BAKING, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Nutritional Yeast", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== CANNED =====
+        profile(m, "Black Beans", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Kidney Beans", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pinto Beans", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chickpeas", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chicken Broth", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Beef Broth", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Vegetable Broth", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Coconut Milk", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Crushed Tomatoes", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Diced Tomatoes", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tomato Paste", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tomato Sauce", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Enchilada Sauce", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Green Chiles", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Roasted Red Peppers", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Capers", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Olives", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sun-Dried Tomatoes", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Artichoke Hearts", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Canned Corn", PANTRY, CANNED, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Marinara Sauce", PANTRY, CANNED, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== NUTS & SEEDS =====
+        profile(m, "Almonds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sliced Almonds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Cashew Nuts", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Peanuts", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Peanut Butter", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pecans", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pine Nuts", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sesame Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sunflower Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pumpkin Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Walnuts", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chia Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Flax Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Hemp Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Poppy Seeds", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Coconut Flakes", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Shredded Coconut", PANTRY, BAKING, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== FROZEN =====
+        profile(m, "Frozen Berries", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Corn", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Mixed Vegetables", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Peas", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Spinach", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Broccoli", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Shrimp", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Frozen Chicken Tenders", StorageCategory.FROZEN, GroceryCategory.FROZEN, DAIRY_FREE, NUT_FREE);
+        profile(m, "Frozen Pizza Dough", StorageCategory.FROZEN, GroceryCategory.FROZEN, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Frozen Pie Crust", StorageCategory.FROZEN, GroceryCategory.FROZEN, NUT_FREE, VEGETARIAN);
+        profile(m, "Frozen Fruit", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Ice Cream", StorageCategory.FROZEN, GroceryCategory.FROZEN, GLUTEN_FREE, NUT_FREE, VEGETARIAN);
+
+        // ===== BAKERY =====
+        profile(m, "Bread", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Hamburger Buns", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Hot Dog Buns", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Pita Bread", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Naan", COUNTER, BAKERY, NUT_FREE, VEGETARIAN);
+        profile(m, "French Bread", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sourdough Bread", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Croissants", COUNTER, BAKERY, NUT_FREE, VEGETARIAN);
+        profile(m, "English Muffins", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Bagels", COUNTER, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Croutons", PANTRY, BAKERY, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Pizza Dough", REFRIGERATED, BAKERY, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== HOUSEHOLD & WATER =====
+        profile(m, "Water", COUNTER, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Ice", COUNTER, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+
+        // ===== BEVERAGES =====
+        profile(m, "Green Tea Bags", PANTRY, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Black Tea Bags", PANTRY, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Coffee", PANTRY, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Matcha Powder", PANTRY, HOUSEHOLD, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+
+        // ===== HEALTH SUPPLEMENTS =====
+        profile(m, "Baobab Boost Powder", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Integral Collagen", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, SUGAR_FREE);
+        profile(m, "Just Gelatin", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, SUGAR_FREE);
+        profile(m, "Pure Stevia Extract Powder", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN, SUGAR_FREE);
+        profile(m, "Sunflower Lecithin", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Protein Powder", PANTRY, BULK, GLUTEN_FREE, NUT_FREE);
+        profile(m, "Whey Protein", PANTRY, BULK, GLUTEN_FREE, NUT_FREE);
+        profile(m, "Collagen Peptides", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, SUGAR_FREE);
+        profile(m, "MCT Oil", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Apple Cider Vinegar Gummies", PANTRY, BULK, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== ETHNIC / SPECIALTY =====
+        profile(m, "Gochujang", PANTRY, ETHNIC, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sambal Oelek", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Curry Paste", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Harissa", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Chipotle Peppers in Adobo", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Wonton Wrappers", REFRIGERATED, ETHNIC, DAIRY_FREE, NUT_FREE, VEGETARIAN);
+        profile(m, "Spring Roll Wrappers", PANTRY, ETHNIC, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Coconut Cream", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Tamarind Paste", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Nori Sheets", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Mirin", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Sake", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Dried Lentils", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Red Lentils", PANTRY, ETHNIC, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        // ===== DELI =====
+        profile(m, "Deli Turkey", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Deli Ham", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE);
+        profile(m, "Hummus", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+        profile(m, "Guacamole", REFRIGERATED, DELI, GLUTEN_FREE, DAIRY_FREE, NUT_FREE, VEGAN, VEGETARIAN);
+
+        PROFILES = Map.copyOf(m);
+    }
+
+    private IngredientKnowledgeBase() {}
+
+    public static Optional<IngredientProfile> lookup(String ingredientName) {
+        if (ingredientName == null || ingredientName.isBlank()) return Optional.empty();
+        return Optional.ofNullable(PROFILES.get(ingredientName.toLowerCase()));
+    }
+
+    public static int size() {
+        return PROFILES.size();
+    }
+
+    private static void profile(Map<String, IngredientProfile> map,
+                                String canonicalName,
+                                StorageCategory storage,
+                                GroceryCategory grocery,
+                                DietaryTag... tags) {
+        map.put(canonicalName.toLowerCase(),
+                new IngredientProfile(storage, grocery, Set.of(tags)));
+    }
+}

--- a/src/main/java/com/endoran/foodplan/service/IngredientLinkerService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientLinkerService.java
@@ -70,6 +70,8 @@ public class IngredientLinkerService {
                         }
                     }
                     newIng.setDietaryTags(tags);
+                } else {
+                    newIng.setDietaryTags(IngredientCategoryInference.infer(sri.getIngredientName()).dietaryTags());
                 }
 
                 newIng.setNeedsReview(false);

--- a/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientNormalizationService.java
@@ -1,7 +1,10 @@
 package com.endoran.foodplan.service;
 
+import com.endoran.foodplan.model.DietaryTag;
+import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.model.Ingredient;
 import com.endoran.foodplan.model.InventoryItem;
+import com.endoran.foodplan.model.StorageCategory;
 import com.endoran.foodplan.repository.IngredientRepository;
 import com.endoran.foodplan.repository.InventoryItemRepository;
 import org.slf4j.Logger;
@@ -15,8 +18,10 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 public class IngredientNormalizationService {
@@ -39,6 +44,7 @@ public class IngredientNormalizationService {
         List<Ingredient> ingredients = ingredientRepository.findByOrgId(orgId);
         List<Rename> renames = new ArrayList<>();
         List<Merge> merges = new ArrayList<>();
+        List<CategoryFix> categoryFixes = new ArrayList<>();
         int skipped = 0;
 
         Map<String, List<Ingredient>> groups = new HashMap<>();
@@ -72,6 +78,41 @@ public class IngredientNormalizationService {
             }
         }
 
+        // Category fix pass: re-enrich needsReview ingredients using KB
+        Set<String> mergedLoserIds = new HashSet<>();
+        for (Merge merge : merges) {
+            mergedLoserIds.add(merge.loserId);
+        }
+
+        for (Ingredient ing : ingredients) {
+            if (mergedLoserIds.contains(ing.getId())) continue;
+            if (!ing.isNeedsReview()) continue;
+
+            String lookupName = renames.stream()
+                    .filter(r -> r.ingredientId.equals(ing.getId()))
+                    .map(Rename::newName)
+                    .findFirst()
+                    .orElse(ing.getName());
+
+            var profile = IngredientKnowledgeBase.lookup(lookupName);
+            if (profile.isEmpty()) continue;
+
+            var p = profile.get();
+            boolean categoryChanged = ing.getStorageCategory() != p.storage()
+                    || ing.getGroceryCategory() != p.grocery();
+            boolean tagsChanged = !p.dietaryTags().equals(ing.getDietaryTags() != null
+                    ? ing.getDietaryTags() : Set.of());
+
+            if (categoryChanged || tagsChanged) {
+                categoryFixes.add(new CategoryFix(
+                        ing.getId(), lookupName,
+                        ing.getStorageCategory(), p.storage(),
+                        ing.getGroceryCategory(), p.grocery(),
+                        ing.getDietaryTags() != null ? ing.getDietaryTags() : Set.of(),
+                        p.dietaryTags()));
+            }
+        }
+
         if (!dryRun) {
             for (Rename rename : renames) {
                 Ingredient ing = ingredientRepository.findById(rename.ingredientId).orElse(null);
@@ -94,12 +135,23 @@ public class IngredientNormalizationService {
                     }
                 }
             }
+
+            for (CategoryFix fix : categoryFixes) {
+                Ingredient ing = ingredientRepository.findById(fix.ingredientId).orElse(null);
+                if (ing != null) {
+                    ing.setStorageCategory(fix.newStorage);
+                    ing.setGroceryCategory(fix.newGrocery);
+                    ing.setDietaryTags(fix.newTags);
+                    ing.setNeedsReview(false);
+                    ingredientRepository.save(ing);
+                }
+            }
         }
 
-        log.info("Normalization for org {}: {} renames, {} merges, {} skipped (dryRun={})",
-                orgId, renames.size(), merges.size(), skipped, dryRun);
+        log.info("Normalization for org {}: {} renames, {} merges, {} category fixes, {} skipped (dryRun={})",
+                orgId, renames.size(), merges.size(), categoryFixes.size(), skipped, dryRun);
 
-        return new NormalizationResult(renames, merges, skipped);
+        return new NormalizationResult(renames, merges, categoryFixes, skipped);
     }
 
     private Ingredient pickWinner(Ingredient a, Ingredient b) {
@@ -150,6 +202,7 @@ public class IngredientNormalizationService {
     public record NormalizationResult(
             List<Rename> renames,
             List<Merge> merges,
+            List<CategoryFix> categoryFixes,
             int skipped
     ) {}
 
@@ -157,4 +210,12 @@ public class IngredientNormalizationService {
 
     public record Merge(String winnerId, String winnerName, String loserId,
                          String loserName, String canonicalName) {}
+
+    public record CategoryFix(
+            String ingredientId,
+            String ingredientName,
+            StorageCategory oldStorage, StorageCategory newStorage,
+            GroceryCategory oldGrocery, GroceryCategory newGrocery,
+            Set<DietaryTag> oldTags, Set<DietaryTag> newTags
+    ) {}
 }

--- a/src/main/java/com/endoran/foodplan/service/IngredientService.java
+++ b/src/main/java/com/endoran/foodplan/service/IngredientService.java
@@ -85,13 +85,14 @@ public class IngredientService {
                 return new IngredientPreparation(
                         normalized, IngredientPreparation.Status.EXISTING,
                         ing.getStorageCategory(), ing.getGroceryCategory(),
-                        ing.isShoppingListExclude());
+                        ing.getDietaryTags(), ing.isShoppingListExclude());
             }
             IngredientCategoryInference.InferredCategories inferred =
                     IngredientCategoryInference.infer(normalized);
             return new IngredientPreparation(
                     normalized, IngredientPreparation.Status.NEW,
-                    inferred.storage(), inferred.grocery(), false);
+                    inferred.storage(), inferred.grocery(),
+                    inferred.dietaryTags(), false);
         }).toList();
     }
 
@@ -136,6 +137,8 @@ public class IngredientService {
                             IngredientCategoryInference.infer(ing.getName());
                     ing.setStorageCategory(inferred.storage());
                     ing.setGroceryCategory(inferred.grocery());
+                    ing.setDietaryTags(inferred.dietaryTags());
+                    ing.setNeedsReview(IngredientKnowledgeBase.lookup(ing.getName()).isEmpty());
                 })
                 .toList();
         ingredientRepository.saveAll(updated);

--- a/src/main/java/com/endoran/foodplan/service/RecipeService.java
+++ b/src/main/java/com/endoran/foodplan/service/RecipeService.java
@@ -266,7 +266,8 @@ public class RecipeService {
                     newIng.setName(ri.getIngredientName());
                     newIng.setStorageCategory(inferred.storage());
                     newIng.setGroceryCategory(inferred.grocery());
-                    newIng.setNeedsReview(true);
+                    newIng.setDietaryTags(inferred.dietaryTags());
+                    newIng.setNeedsReview(IngredientKnowledgeBase.lookup(ri.getIngredientName()).isEmpty());
                     newIng = ingredientRepository.save(newIng);
                     ri.setIngredientId(newIng.getId());
                     ingredientsCreated++;
@@ -298,7 +299,8 @@ public class RecipeService {
                 newIng.setName(ri.getIngredientName());
                 newIng.setStorageCategory(inferred.storage());
                 newIng.setGroceryCategory(inferred.grocery());
-                newIng.setNeedsReview(true);
+                newIng.setDietaryTags(inferred.dietaryTags());
+                newIng.setNeedsReview(IngredientKnowledgeBase.lookup(ri.getIngredientName()).isEmpty());
                 newIng = ingredientRepository.save(newIng);
                 ri.setIngredientId(newIng.getId());
             }

--- a/src/test/java/com/endoran/foodplan/service/IngredientCategoryInferenceTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientCategoryInferenceTest.java
@@ -1,11 +1,12 @@
 package com.endoran.foodplan.service;
 
+import com.endoran.foodplan.model.DietaryTag;
 import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.model.StorageCategory;
 import com.endoran.foodplan.service.IngredientCategoryInference.InferredCategories;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class IngredientCategoryInferenceTest {
 
@@ -14,6 +15,7 @@ class IngredientCategoryInferenceTest {
         InferredCategories result = IngredientCategoryInference.infer("Chicken Breast");
         assertEquals(StorageCategory.REFRIGERATED, result.storage());
         assertEquals(GroceryCategory.MEAT, result.grocery());
+        assertFalse(result.dietaryTags().contains(DietaryTag.VEGAN));
     }
 
     @Test
@@ -28,6 +30,7 @@ class IngredientCategoryInferenceTest {
         InferredCategories result = IngredientCategoryInference.infer("Cheddar Cheese");
         assertEquals(StorageCategory.REFRIGERATED, result.storage());
         assertEquals(GroceryCategory.DAIRY, result.grocery());
+        assertTrue(result.dietaryTags().contains(DietaryTag.VEGETARIAN));
     }
 
     @Test
@@ -101,9 +104,9 @@ class IngredientCategoryInferenceTest {
     }
 
     @Test
-    void lettuceDefaultsToProduce() {
+    void romaineLettuceIsFreshProduce() {
         InferredCategories result = IngredientCategoryInference.infer("Romaine Lettuce");
-        assertEquals(StorageCategory.PANTRY, result.storage());
+        assertEquals(StorageCategory.FRESH, result.storage());
         assertEquals(GroceryCategory.PRODUCE, result.grocery());
     }
 
@@ -133,5 +136,43 @@ class IngredientCategoryInferenceTest {
         InferredCategories result = IngredientCategoryInference.infer("Chicken Stock");
         assertEquals(StorageCategory.PANTRY, result.storage());
         assertEquals(GroceryCategory.CANNED, result.grocery());
+    }
+
+    @Test
+    void kbHitReturnsDietaryTags() {
+        InferredCategories result = IngredientCategoryInference.infer("Olive Oil");
+        assertNotNull(result.dietaryTags());
+        assertTrue(result.dietaryTags().contains(DietaryTag.VEGAN));
+        assertTrue(result.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+    }
+
+    @Test
+    void keywordFallbackReturnsDietaryTags() {
+        InferredCategories result = IngredientCategoryInference.infer("Exotic Frozen Blend");
+        assertNotNull(result.dietaryTags());
+        assertFalse(result.dietaryTags().isEmpty());
+    }
+
+    @Test
+    void unknownIngredientGetsDefaultTags() {
+        InferredCategories result = IngredientCategoryInference.infer("Pixie Dust");
+        assertEquals(StorageCategory.PANTRY, result.storage());
+        assertEquals(GroceryCategory.PRODUCE, result.grocery());
+        assertTrue(result.dietaryTags().contains(DietaryTag.VEGAN));
+        assertTrue(result.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+    }
+
+    @Test
+    void groundBlackPepperIsSpicesViaKb() {
+        InferredCategories result = IngredientCategoryInference.infer("Ground Black Pepper");
+        assertEquals(StorageCategory.SPICE_RACK, result.storage());
+        assertEquals(GroceryCategory.SPICES, result.grocery());
+    }
+
+    @Test
+    void anchovyPasteIsOilsCondimentsViaKb() {
+        InferredCategories result = IngredientCategoryInference.infer("Anchovy Paste");
+        assertEquals(StorageCategory.PANTRY, result.storage());
+        assertEquals(GroceryCategory.OILS_CONDIMENTS, result.grocery());
     }
 }

--- a/src/test/java/com/endoran/foodplan/service/IngredientKnowledgeBaseTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientKnowledgeBaseTest.java
@@ -1,0 +1,173 @@
+package com.endoran.foodplan.service;
+
+import com.endoran.foodplan.model.DietaryTag;
+import com.endoran.foodplan.model.GroceryCategory;
+import com.endoran.foodplan.model.StorageCategory;
+import com.endoran.foodplan.service.IngredientKnowledgeBase.IngredientProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IngredientKnowledgeBaseTest {
+
+    @Test
+    void parmesanCheeseIsDairy() {
+        Optional<IngredientProfile> profile = IngredientKnowledgeBase.lookup("Parmesan Cheese");
+        assertTrue(profile.isPresent());
+        assertEquals(StorageCategory.REFRIGERATED, profile.get().storage());
+        assertEquals(GroceryCategory.DAIRY, profile.get().grocery());
+        assertTrue(profile.get().dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+        assertTrue(profile.get().dietaryTags().contains(DietaryTag.VEGETARIAN));
+        assertFalse(profile.get().dietaryTags().contains(DietaryTag.VEGAN));
+    }
+
+    @Test
+    void unknownIngredientReturnsEmpty() {
+        assertTrue(IngredientKnowledgeBase.lookup("Pixie Dust").isEmpty());
+    }
+
+    @Test
+    void lookupIsCaseInsensitive() {
+        assertTrue(IngredientKnowledgeBase.lookup("PARMESAN CHEESE").isPresent());
+        assertTrue(IngredientKnowledgeBase.lookup("parmesan cheese").isPresent());
+        assertTrue(IngredientKnowledgeBase.lookup("Parmesan Cheese").isPresent());
+    }
+
+    @Test
+    void nullAndBlankReturnEmpty() {
+        assertTrue(IngredientKnowledgeBase.lookup(null).isEmpty());
+        assertTrue(IngredientKnowledgeBase.lookup("").isEmpty());
+        assertTrue(IngredientKnowledgeBase.lookup("   ").isEmpty());
+    }
+
+    // Staging misclassification fixes
+    @Test
+    void anchovyPasteIsOilsCondiments() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Anchovy Paste").orElseThrow();
+        assertEquals(StorageCategory.PANTRY, p.storage());
+        assertEquals(GroceryCategory.OILS_CONDIMENTS, p.grocery());
+    }
+
+    @Test
+    void gheeIsOilsCondiments() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Ghee").orElseThrow();
+        assertEquals(StorageCategory.PANTRY, p.storage());
+        assertEquals(GroceryCategory.OILS_CONDIMENTS, p.grocery());
+    }
+
+    @Test
+    void groundBlackPepperIsSpices() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Ground Black Pepper").orElseThrow();
+        assertEquals(StorageCategory.SPICE_RACK, p.storage());
+        assertEquals(GroceryCategory.SPICES, p.grocery());
+    }
+
+    @Test
+    void worcestershireSauceIsOilsCondiments() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Worcestershire Sauce").orElseThrow();
+        assertEquals(StorageCategory.PANTRY, p.storage());
+        assertEquals(GroceryCategory.OILS_CONDIMENTS, p.grocery());
+    }
+
+    @Test
+    void romaineLettuceIsFreshProduce() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Romaine Lettuce").orElseThrow();
+        assertEquals(StorageCategory.FRESH, p.storage());
+        assertEquals(GroceryCategory.PRODUCE, p.grocery());
+    }
+
+    @Test
+    void rainbowBellPeppersIsFreshProduce() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Rainbow Bell Peppers").orElseThrow();
+        assertEquals(StorageCategory.FRESH, p.storage());
+        assertEquals(GroceryCategory.PRODUCE, p.grocery());
+    }
+
+    @Test
+    void lemonJuiceIsOilsCondiments() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Lemon Juice").orElseThrow();
+        assertEquals(StorageCategory.PANTRY, p.storage());
+        assertEquals(GroceryCategory.OILS_CONDIMENTS, p.grocery());
+    }
+
+    @Test
+    void mineralSaltIsSpices() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Mineral Salt").orElseThrow();
+        assertEquals(StorageCategory.SPICE_RACK, p.storage());
+        assertEquals(GroceryCategory.SPICES, p.grocery());
+    }
+
+    // Dietary tag correctness
+    @Test
+    void chickenBreastIsNotVegetarian() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Chicken Breast").orElseThrow();
+        assertFalse(p.dietaryTags().contains(DietaryTag.VEGAN));
+        assertFalse(p.dietaryTags().contains(DietaryTag.VEGETARIAN));
+        assertTrue(p.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+        assertTrue(p.dietaryTags().contains(DietaryTag.DAIRY_FREE));
+    }
+
+    @Test
+    void oliveOilIsFullyPlantBased() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Olive Oil").orElseThrow();
+        assertTrue(p.dietaryTags().contains(DietaryTag.VEGAN));
+        assertTrue(p.dietaryTags().contains(DietaryTag.VEGETARIAN));
+        assertTrue(p.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+        assertTrue(p.dietaryTags().contains(DietaryTag.DAIRY_FREE));
+        assertTrue(p.dietaryTags().contains(DietaryTag.NUT_FREE));
+    }
+
+    @Test
+    void almondFlourIsNotNutFree() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Almond Flour").orElseThrow();
+        assertFalse(p.dietaryTags().contains(DietaryTag.NUT_FREE));
+        assertTrue(p.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+    }
+
+    @Test
+    void eggsAreDairyFree() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Eggs").orElseThrow();
+        assertTrue(p.dietaryTags().contains(DietaryTag.DAIRY_FREE));
+        assertFalse(p.dietaryTags().contains(DietaryTag.VEGAN));
+        assertTrue(p.dietaryTags().contains(DietaryTag.VEGETARIAN));
+    }
+
+    @Test
+    void soyStateContainsWheatNotGlutenFree() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Soy Sauce").orElseThrow();
+        assertFalse(p.dietaryTags().contains(DietaryTag.GLUTEN_FREE));
+    }
+
+    @Test
+    void kbHasSubstantialCoverage() {
+        assertTrue(IngredientKnowledgeBase.size() >= 300);
+    }
+
+    // Health supplements that were misclassified in staging
+    @Test
+    void healthSupplementsAreBulk() {
+        assertEquals(GroceryCategory.BULK,
+                IngredientKnowledgeBase.lookup("Baobab Boost Powder").orElseThrow().grocery());
+        assertEquals(GroceryCategory.BULK,
+                IngredientKnowledgeBase.lookup("Integral Collagen").orElseThrow().grocery());
+        assertEquals(GroceryCategory.BULK,
+                IngredientKnowledgeBase.lookup("Pure Stevia Extract Powder").orElseThrow().grocery());
+        assertEquals(GroceryCategory.BULK,
+                IngredientKnowledgeBase.lookup("Sunflower Lecithin").orElseThrow().grocery());
+    }
+
+    @Test
+    void greenTeaBagsIsHousehold() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Green Tea Bags").orElseThrow();
+        assertEquals(GroceryCategory.HOUSEHOLD, p.grocery());
+        assertEquals(StorageCategory.PANTRY, p.storage());
+    }
+
+    @Test
+    void matchaPowderIsHousehold() {
+        IngredientProfile p = IngredientKnowledgeBase.lookup("Matcha Powder").orElseThrow();
+        assertEquals(GroceryCategory.HOUSEHOLD, p.grocery());
+    }
+}

--- a/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
+++ b/src/test/java/com/endoran/foodplan/service/IngredientNormalizationServiceTest.java
@@ -1,9 +1,11 @@
 package com.endoran.foodplan.service;
 
+import com.endoran.foodplan.model.DietaryTag;
 import com.endoran.foodplan.model.GroceryCategory;
 import com.endoran.foodplan.model.Ingredient;
 import com.endoran.foodplan.model.InventoryItem;
 import com.endoran.foodplan.model.MeasurementUnit;
+import com.endoran.foodplan.model.StorageCategory;
 import com.endoran.foodplan.repository.IngredientRepository;
 import com.endoran.foodplan.repository.InventoryItemRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +64,7 @@ class IngredientNormalizationServiceTest {
 
         assertEquals(1, result.renames().size());
         assertEquals("Garlic Powder", result.renames().get(0).newName());
-        verify(ingredientRepository).save(ing);
+        verify(ingredientRepository, atLeastOnce()).save(ing);
         assertEquals("Garlic Powder", ing.getName());
     }
 
@@ -207,6 +209,69 @@ class IngredientNormalizationServiceTest {
         ing.setName(name);
         ing.setNeedsReview(needsReview);
         ing.setGroceryCategory(GroceryCategory.PRODUCE);
+        ing.setStorageCategory(StorageCategory.PANTRY);
         return ing;
+    }
+
+    @Test
+    void categoryFixesReportedInDryRun() {
+        Ingredient ing = makeIngredient("1", "Parmesan Cheese", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+
+        var result = service.normalizeAll("org1", true);
+
+        assertEquals(1, result.categoryFixes().size());
+        var fix = result.categoryFixes().get(0);
+        assertEquals("Parmesan Cheese", fix.ingredientName());
+        assertEquals(GroceryCategory.PRODUCE, fix.oldGrocery());
+        assertEquals(GroceryCategory.DAIRY, fix.newGrocery());
+        assertEquals(StorageCategory.PANTRY, fix.oldStorage());
+        assertEquals(StorageCategory.REFRIGERATED, fix.newStorage());
+        verify(ingredientRepository, never()).save(any());
+    }
+
+    @Test
+    void categoryFixesAppliedOnExecute() {
+        Ingredient ing = makeIngredient("1", "Parmesan Cheese", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+        when(ingredientRepository.findById("1")).thenReturn(Optional.of(ing));
+
+        service.normalizeAll("org1", false);
+
+        assertEquals(GroceryCategory.DAIRY, ing.getGroceryCategory());
+        assertEquals(StorageCategory.REFRIGERATED, ing.getStorageCategory());
+        assertFalse(ing.isNeedsReview());
+        assertFalse(ing.getDietaryTags().isEmpty());
+        verify(ingredientRepository).save(ing);
+    }
+
+    @Test
+    void manuallyReviewedIngredientsNotFixed() {
+        Ingredient ing = makeIngredient("1", "Parmesan Cheese", false);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(ing));
+
+        var result = service.normalizeAll("org1", false);
+
+        assertEquals(0, result.categoryFixes().size());
+    }
+
+    @Test
+    void mergedLosersExcludedFromCategoryFixes() {
+        Ingredient winner = makeIngredient("1", "Garlic Powder", false);
+        Ingredient loser = makeIngredient("2", "garlic powder", true);
+        when(ingredientRepository.findByOrgId("org1")).thenReturn(List.of(winner, loser));
+        when(ingredientRepository.findById(anyString())).thenAnswer(inv -> {
+            String id = inv.getArgument(0);
+            if ("1".equals(id)) return Optional.of(winner);
+            if ("2".equals(id)) return Optional.of(loser);
+            return Optional.empty();
+        });
+        when(inventoryItemRepository.findByOrgId("org1")).thenReturn(List.of());
+
+        var result = service.normalizeAll("org1", false);
+
+        for (var fix : result.categoryFixes()) {
+            assertNotEquals("2", fix.ingredientId());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **IngredientKnowledgeBase** — new static lookup of 349 ingredient profiles (storage, grocery, dietary tags), organized by section (dairy, proteins, produce, spices, etc.)
- **KB-first inference** — `IngredientCategoryInference.infer()` consults KB via exact match before falling back to keyword rules. All 6+ existing call sites get accurate classifications with zero changes.
- **Dietary tags on all creation paths** — `InferredCategories` record now includes `Set<DietaryTag>`. RecipeService, IngredientService, GlobalRecipeService, and IngredientLinkerService all propagate tags.
- **`needsReview` semantics changed** — now `false` when KB has a match (confident), `true` only for keyword-fallback (guessing). Nobody was reviewing anyway.
- **Batch normalization CategoryFix pass** — normalizeAll() now corrects storage/grocery/tags on `needsReview=true` ingredients against the KB and clears the flag. Frontend preview shows fixes alongside renames/merges.
- **Expanded alias dictionary** — water variants, lemon/lime juice, parmesan aliases, cooked chicken breast
- Fixes all 8 known misclassifications from staging (Parmesan→DAIRY, Ghee→OILS_CONDIMENTS, etc.)

## Test plan

- [x] `gradle compileJava` passes
- [x] `npx tsc --noEmit` passes (frontend)
- [x] 88 unit tests pass (`gradle test`)
- [x] IngredientKnowledgeBaseTest — profiles, case insensitivity, null/blank, all staging misclassifications, dietary tag correctness, coverage ≥300
- [x] IngredientCategoryInferenceTest — KB hits, keyword fallback, unknown defaults, dietary tags
- [x] IngredientNormalizationServiceTest — category fixes in dry run, applied on execute, manually-reviewed skipped, merged losers excluded
- [ ] Run normalize dry-run on staging → verify category fixes appear for needsReview ingredients
- [ ] Run normalize execute → verify categories corrected, needsReview cleared